### PR TITLE
[feat]: multer 사전 설정

### DIFF
--- a/modules/multer.js
+++ b/modules/multer.js
@@ -1,0 +1,23 @@
+const multer = require('multer');
+const multerS3 = require('multer-s3');
+const aws = require('aws-sdk');
+aws.config.loadFromPath(__dirname + '/../config/s3.json');
+
+const s3 = new aws.S3();
+const upload = multer({
+  storage: multerS3({
+    s3,
+    bucket: 'sopt-27',
+    acl: 'public-read',
+    key: function (req, file, cb) {
+      cb(
+        null,
+        'images/origin/' +
+          Date.now() +
+          '.' +
+          file.originalname.split('.').pop(),
+      );
+    },
+  }),
+});
+module.exports = upload;

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
+    "aws-sdk": "^2.820.0",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "express": "~4.16.1",
     "http-errors": "~1.6.3",
     "jsonwebtoken": "^8.5.1",
     "morgan": "~1.9.1",
+    "multer": "^1.4.2",
+    "multer-s3": "^2.9.0",
     "mysql2": "^2.2.5",
     "sequelize": "^6.3.5",
     "sequelize-cli": "^6.2.0"


### PR DESCRIPTION
## 작업사항

multer를 사용하기 위한 사전 작업 수행,

- 필요 모듈 설치 목록
  - multer
  - multer-s3
  - aws-sdk

- 미들웨어로 등록하기 위한 modules/multer.js 생성
  - multer.js
```
const multer = require('multer');
const multerS3 = require('multer-s3');
const aws = require('aws-sdk');
aws.config.loadFromPath(__dirname + '/../config/s3.json');

const s3 = new aws.S3();
const upload = multer({
  storage: multerS3({
    s3,
    bucket: 'sopt-27',
    acl: 'public-read',
    key: function (req, file, cb) {
      cb(
        null,
        'images/origin/' +
          Date.now() +
          '.' +
          file.originalname.split('.').pop(),
      );
    },
  }),
});
module.exports = upload;
```

## 사용방법

상기 multer.js를 모듈로 불러와 미들웨어로 사용

ex)

```
const upload = require('modules/multer.js');

router.post('/upload', upload.single('file'), async function(res, req) {
  // body
});
```

### 희망 리뷰 완료일

2021.01.03

### 관계된 이슈, PR 

related to #9 