### PR TITLE
[fix]: 잘못된 s3의 버켓 위치를 수정

### DIFF
--- a/modules/multer.js
+++ b/modules/multer.js
@@ -1,0 +1,23 @@
+const multer = require('multer');
+const multerS3 = require('multer-s3');
+const aws = require('aws-sdk');
+aws.config.loadFromPath(__dirname + '/../config/s3.json');
+
+const s3 = new aws.S3();
+const upload = multer({
+  storage: multerS3({
+    s3,
+    bucket: 'sopt-27',
+    acl: 'public-read',
+    key: function (req, file, cb) {
+      cb(
+        null,
+        'images/origin/' +
+          Date.now() +
+          '.' +
+          file.originalname.split('.').pop(),
+      );
+    },
+  }),
+});
+module.exports = upload;

--- a/modules/multer.js
+++ b/modules/multer.js
@@ -1,13 +1,14 @@
 const multer = require('multer');
 const multerS3 = require('multer-s3');
 const aws = require('aws-sdk');
+
 aws.config.loadFromPath(__dirname + '/../config/s3.json');
 
 const s3 = new aws.S3();
 const upload = multer({
   storage: multerS3({
     s3,
-    bucket: 'sopt-27',
+    bucket: 'meaning-s3-bucket',
     acl: 'public-read',
     key: function (req, file, cb) {
       cb(

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
+    "aws-sdk": "^2.820.0",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "express": "~4.16.1",
     "http-errors": "~1.6.3",
     "jsonwebtoken": "^8.5.1",
     "morgan": "~1.9.1",
+    "multer": "^1.4.2",
+    "multer-s3": "^2.9.0",
     "mysql2": "^2.2.5",
     "sequelize": "^6.3.5",
     "sequelize-cli": "^6.2.0"


### PR DESCRIPTION
## 작업사항

s3의 버켓 위치가 잘못 잡혀있었습니다.
meaning을 위해 할당받은 s3의 스토리지로 파일이 업로드 되도록 설정값을 수정했습니다.

## 변경로직

### 변경전

```
...(생략)...
const s3 = new aws.S3();
const upload = multer({
  storage: multerS3({
    s3,
    bucket: 'sopt-27',
...(생략)...
```

### 변경후

```
...(생략)...
const s3 = new aws.S3();
const upload = multer({
  storage: multerS3({
    s3,
    bucket: 'meaning-s3-bucket',  // modified
...(생략)...
```

### 희망 리뷰 완료일

2021.01.03

### 관계된 이슈, PR 

related to #9