### PR TITLE
[fix]: 타임스탬프 작성 요청시, 파라미터 누락 검증 로직 추가

### DIFF
--- a/controller/timeStampController.js
+++ b/controller/timeStampController.js
@@ -17,6 +17,17 @@ module.exports = {
       const timeStampImageUrl = req.file.location;
       const { dateTime, timeStampContents } = req.body;
 
+      if (!dateTime || !timeStampContents || !timeStampImageUrl) {
+        return res
+          .status(statusCode.BAD_REQUEST)
+          .send(
+            util.fail(
+              statusCode.BAD_REQUEST,
+              responseMessage.NULL_VALUE,
+            ),
+          );
+      }
+
       if (!dateTimeModule.checkValidDateTimeFormat(dateTime)) { // check valid format
         return res
           .status(statusCode.BAD_REQUEST)


### PR DESCRIPTION
- 누락 파라미터에 대한 검증 로직이 부재한 점을 발견했습니다. 이에 해당 로직을 추가하고 다시 pull을 요청합니다.

## 작업사항

- 요청 시 파라미터 누락에 대해 검사하는 과정 추가

### 추가 사항

> timeStampController.js
```
...(생략)...

if (!dateTime || !timeStampContents || !timeStampImageUrl) {
  return res
    .status(statusCode.BAD_REQUEST)
    .send(
      util.fail(
        statusCode.BAD_REQUEST,
        responseMessage.NULL_VALUE,
      ),
    );
}

...(생략)...
```

### 희망 리뷰 완료일

2021-01-06

### 관계된 이슈, PR 

#9 