### PR TITLE
[feat] 온보드 정보 등록 요청 API

### DIFF
--- a/controller/userController.js
+++ b/controller/userController.js
@@ -6,6 +6,8 @@ const util = require('../modules/util');
 const responseMessage = require('../modules/responseMessage');
 const statusCode = require('../modules/statusCode');
 
+const dateTimeModule = require('../modules/dateTimeModule');
+
 const userService = require('../service/userService');
 
 module.exports = {
@@ -114,15 +116,69 @@ module.exports = {
 
       let successDays = 0;
 
-      getMySuccessDay.forEach((day) =>
-        successDays += day.status);
+      getMySuccessDay.forEach(day => (successDays += day.status));
 
-      return res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_TIMESTAMP_ALL_SUCCESS, { successDays, getMyPage }));
+      return res
+        .status(statusCode.OK)
+        .send(
+          util.success(
+            statusCode.OK,
+            responseMessage.READ_TIMESTAMP_ALL_SUCCESS,
+            { successDays, getMyPage },
+          ),
+        );
     } catch (error) {
       console.log(error);
       res
         .status(statusCode.INTERNAL_SERVER_ERROR)
-        .send(util.fail(statusCode.BAD_REQUEST, responseMessage.READ_TIMESTAMP_ALL_FAIL));
+        .send(
+          util.fail(
+            statusCode.BAD_REQUEST,
+            responseMessage.READ_TIMESTAMP_ALL_FAIL,
+          ),
+        );
+    }
+  },
+  updateOnboard: async (req, res) => {
+    try {
+      const { id } = req.decoded;
+      const { nickName, wakeUpTime } = req.body;
+
+      if (!nickName || !wakeUpTime) {
+        res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+      }
+
+      if (!dateTimeModule.checkValidTimeFormat(wakeUpTime)) {
+        res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.INVALID_TIME_FORMAT));
+      }
+
+      const user = await userService.updateOnboard(id, nickName, wakeUpTime);
+
+      if (!user) {
+        res
+          .status(statusCode.INTERNAL_SERVER_ERROR)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.UPDATE_ONBOARD_FAIL));
+      }
+
+      return res
+        .status(statusCode.OK)
+        .send(
+          util.success(statusCode.NO_CONTENT, responseMessage.UPDATE_ONBOARD_SUCCESS),
+        );
+    } catch (error) {
+      console.log(error);
+      res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(
+          util.fail(
+            statusCode.INTERNAL_SERVER_ERROR,
+            responseMessage.UPDATE_FAIL,
+          ),
+        );
     }
   },
 };

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -10,6 +10,11 @@ module.exports = {
   SIGN_IN_SUCCESS: '로그인 성공.',
   SIGN_IN_FAIL: '로그인 실패.',
 
+  /* 온보드 정보 등록 */
+  UPDATE_ONBOARD_SUCCESS: '온보드 정보 등록 성공',
+  UPDATE_ONBOARD_FAIL: '온보드 정보 등록 실패',
+  INVALID_TIME_FORMAT: '유효하지 않은 시간 정보 포맷입니다.',
+
   /* 회원관리 */
   ALREADY_ID: '존재하는 ID 입니다.',
   NO_USER: '존재하지않는 유저 id 입니다.',

--- a/routes/users/index.js
+++ b/routes/users/index.js
@@ -8,6 +8,8 @@ router.post('/signup', userController.signup);
 router.post('/signin', userController.signin);
 router.put('/refreshtoken', isLoggedIn.reIssue);
 
+router.put('/onboard', isLoggedIn.checkToken, userController.updateOnboard);
+
 router.get('/mypage', isLoggedIn.checkToken, userController.getMyPage);
 
 module.exports = router;

--- a/service/userService.js
+++ b/service/userService.js
@@ -1,10 +1,11 @@
+/* eslint-disable no-param-reassign */
 /* eslint-disable no-useless-catch */
 
 const crypto = require('crypto');
 const { User, TimeStamp } = require('../models');
 
 module.exports = {
-  checkEmail: async (email) => {
+  checkEmail: async email => {
     try {
       const alreadyEmail = await User.findOne({
         where: {
@@ -75,14 +76,19 @@ module.exports = {
         where: {
           UserId: id,
         },
-        attributes: ['id', 'timeStampImageUrl', 'timeStampContents', 'createdAt'],
+        attributes: [
+          'id',
+          'timeStampImageUrl',
+          'timeStampContents',
+          'createdAt',
+        ],
       });
       return getMyPage;
     } catch (err) {
       throw err;
     }
   },
-  getMySuccessDay: async (id) => {
+  getMySuccessDay: async id => {
     try {
       const getMySuccessDay = await TimeStamp.findAll({
         where: {
@@ -104,6 +110,24 @@ module.exports = {
         attributes: ['wakeUpTime'],
       });
       return wakeUpTime;
+    } catch (err) {
+      throw err;
+    }
+  },
+  updateOnboard: async (id, nickName, wakeUpTime) => {
+    try {
+      const user = await User.update(
+        {
+          nickName,
+          wakeUpTime,
+        },
+        {
+          where: {
+            id,
+          },
+        },
+      );
+      return user;
     } catch (err) {
       throw err;
     }


### PR DESCRIPTION
## 작업사항

- 회원 가입 후, 온보드 상에서 등록할 정보(닉네임, 기상시간)을 서버에 등록하는 API를 구현하였습니다.

## 사용방법
- PUT 메소드로 헤더, 바디를 필요로합니다. 명세서 참고를 부탁드립니다.
[API 명세서](https://github.com/nneaning/meaning_Server/wiki/%EC%98%A8%EB%B3%B4%EB%93%9C)

### 희망 리뷰 완료일

2021.01.07

### 관계된 이슈, PR 

#19