### PR TITLE
[feat]: 그룹생성 API 생성

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -20,9 +20,9 @@ module.exports = {
         .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
     }
     try {
-      const checkGroupId = await groupService.checkGroupId(id);
+      const checkMemberId = await groupService.checkMemberId(id);
 
-      if (checkGroupId) {
+      if (checkMemberId) {
         console.log('소속된 그룹이 이미 있습니다.');
         return res
           .status(statusCode.BAD_REQUEST)

--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-return-assign */
+/* eslint-disable max-len */
+
+const util = require('../modules/util');
+const responseMessage = require('../modules/responseMessage');
+const statusCode = require('../modules/statusCode');
+
+const groupService = require('../service/groupService');
+
+module.exports = {
+  createGroup: async (req, res) => {
+    const { id } = req.decoded;
+    const { groupName, maximumMemberNumber, introduction } = req.body;
+
+    if (!groupName || !maximumMemberNumber || !introduction) {
+      console.log('필요한 값이 없습니다.');
+      return res
+        .status(statusCode.BAD_REQUEST)
+        .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+    }
+    try {
+      const checkGroupId = await groupService.checkGroupId(id);
+
+      if (checkGroupId) {
+        console.log('소속된 그룹이 이미 있습니다.');
+        return res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_GROUP));
+      }
+
+      const createGroup = await groupService.createGroup(groupName, maximumMemberNumber, introduction);
+      const groupId = createGroup.id;
+
+      const createHostMember = await groupService.createHostMember(id, groupId);
+
+      return res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, responseMessage.CREATE_GROUP_SUCCESS));
+    } catch (error) {
+      console.log(error);
+      return res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.CREATE_GROUP_FAIL));
+    }
+  },
+};

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -32,8 +32,8 @@ module.exports = {
 
       const user = await userService.signup(email, userName, password);
 
-      return res.status(statusCode.OK).send(
-        util.success(statusCode.OK, responseMessage.SIGN_UP_SUCCESS, {
+      return res.status(statusCode.CREATED).send(
+        util.success(statusCode.CREATED, responseMessage.SIGN_UP_SUCCESS, {
           id: user.id,
           email: user.email,
           userName: user.userName,

--- a/models/group.js
+++ b/models/group.js
@@ -2,17 +2,13 @@ module.exports = (sequelize, DataTypes) =>
   sequelize.define(
     'Group',
     {
-      name: {
+      groupName: {
         type: DataTypes.STRING(45),
         allowNull: false,
       },
       introduction: {
         type: DataTypes.STRING(200),
         allowNull: false,
-      },
-      groupImageUrl: {
-        type: DataTypes.STRING(100),
-        allowNull: true,
       },
       maximumMemberNumber: {
         type: DataTypes.INTEGER,

--- a/models/index.js
+++ b/models/index.js
@@ -30,17 +30,16 @@ db.Group = require('./group')(sequelize, Sequelize);
 db.Member = require('./member')(sequelize, Sequelize);
 db.Post = require('./post')(sequelize, Sequelize);
 
-
 /** 1 : N   User : Diary */
 db.User.hasMany(db.Diary, { onDelete: 'cascade' });
 db.Diary.belongsTo(db.User);
 
 /** 1 : N   User : BookComment */
-db.User.hasMany(db.BookComment, {onDelete: 'cascade' })
+db.User.hasMany(db.BookComment, { onDelete: 'cascade' });
 db.BookComment.belongsTo(db.User);
 
 /** 1 : N   User : TimeStamp */
-db.User.hasMany(db.TimeStamp, {onDelete: 'cascade' })
+db.User.hasMany(db.TimeStamp, { onDelete: 'cascade' });
 db.TimeStamp.belongsTo(db.User);
 
 /** N : M   User : Group => Member */

--- a/models/post.js
+++ b/models/post.js
@@ -1,4 +1,4 @@
-module.exports = (sequelize, DataTypes) =>
+module.exports = (sequelize) =>
   sequelize.define(
     'Post',
     {

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -26,7 +26,7 @@ module.exports = {
   /* 그룹 */
   CREATE_GROUP_SUCCESS: '그룹 생성 완료',
   CREATE_GROUP_FAIL: '그룹 생성 실패',
-  ALREADY_CREATED_GROUP: '이미 생성한 그룹 입니다.',
+  ALREADY_GROUP: '이미 그룹에 속해 있습니다.',
 
   /* 토큰 */
   EMPTY_TOKEN: '토큰 값이 없습니다.',

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -23,6 +23,11 @@ module.exports = {
   READ_TIMESTAMP_ALL_SUCCESS: '전체 타임스탬프 조회 성공',
   READ_TIMESTAMP_ALL_FAIL: '전체 타임스탬프 조회 실패',
 
+  /* 그룹 */
+  CREATE_GROUP_SUCCESS: '그룹 생성 완료',
+  CREATE_GROUP_FAIL: '그룹 생성 실패',
+  ALREADY_CREATED_GROUP: '이미 생성한 그룹 입니다.',
+
   /* 토큰 */
   EMPTY_TOKEN: '토큰 값이 없습니다.',
   EXPIRED_TOKEN: '토큰 값이 만료되었습니다.',

--- a/routes/group.js
+++ b/routes/group.js
@@ -1,0 +1,9 @@
+const express = require('express');
+
+const router = express.Router();
+const groupController = require('../controller/groupController');
+const isLoggedIn = require('../middlewares/authUtil');
+
+router.post('/', isLoggedIn.checkToken, groupController.createGroup);
+
+module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,5 +3,6 @@ const express = require('express');
 const router = express.Router();
 
 router.use('/user', require('./users'));
+router.use('/group', require('./group'));
 
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,8 +1,8 @@
 const express = require('express');
 
 const router = express.Router();
-const userController = require('../../controller/userController');
-const isLoggedIn = require('../../middlewares/authUtil');
+const userController = require('../controller/userController');
+const isLoggedIn = require('../middlewares/authUtil');
 
 router.post('/signup', userController.signup);
 router.post('/signin', userController.signin);

--- a/service/groupService.js
+++ b/service/groupService.js
@@ -14,14 +14,14 @@ module.exports = {
       throw err;
     }
   },
-  checkGroupId: async (id) => {
+  checkMemberId: async (id) => {
     try {
-      const findGroupId = await Member.findOne({
+      const findMemberId = await Member.findOne({
         where: {
           UserId: id,
         },
       });
-      return findGroupId;
+      return findMemberId;
     } catch (err) {
       throw err;
     }

--- a/service/groupService.js
+++ b/service/groupService.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-useless-catch */
+const { Group, Member } = require('../models');
+
+module.exports = {
+  createGroup: async (groupName, maximumMemberNumber, introduction) => {
+    try {
+      const makeGroup = await Group.create({
+        groupName,
+        maximumMemberNumber,
+        introduction,
+      });
+      return makeGroup;
+    } catch (err) {
+      throw err;
+    }
+  },
+  checkGroupId: async (id) => {
+    try {
+      const findGroupId = await Member.findOne({
+        where: {
+          UserId: id,
+        },
+      });
+      return findGroupId;
+    } catch (err) {
+      throw err;
+    }
+  },
+  createHostMember: async (id, groupId) => {
+    try {
+      const makeHostMember = await Member.create({
+        isHost: 1,
+        UserId: id,
+        GroupId: groupId,
+      });
+      return makeHostMember;
+    } catch (err) {
+      throw err;
+    }
+  },
+};


### PR DESCRIPTION
## 작업사항

- 그룹 생성 후, 그룹 테이블에 그룹 정보를 등록하고, 맴버 테이블에 유저를 등록하는 API를 구현했습니다.


## 사용방법
- POST 메소드로 헤더, 바디를 필요로합니다. 명세서 참고를 부탁드립니다.
[API 명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EC%83%9D%EC%84%B1)

### 희망 리뷰 완료일

2021.01.07

### 관계된 이슈, PR 

#31 
