### PR TITLE
[feat] 그룹 참가 API

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -26,18 +26,79 @@ module.exports = {
         console.log('소속된 그룹이 이미 있습니다.');
         return res
           .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_GROUP));
+          .send(
+            util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_GROUP),
+          );
       }
 
-      const createGroup = await groupService.createGroup(groupName, maximumMemberNumber, introduction);
+      const createGroup = await groupService.createGroup(
+        groupName,
+        maximumMemberNumber,
+        introduction,
+      );
       const groupId = createGroup.id;
 
       const createHostMember = await groupService.createHostMember(id, groupId);
 
-      return res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, responseMessage.CREATE_GROUP_SUCCESS));
+      return res
+        .status(statusCode.CREATED)
+        .send(
+          util.success(
+            statusCode.CREATED,
+            responseMessage.CREATE_GROUP_SUCCESS,
+          ),
+        );
     } catch (error) {
       console.log(error);
-      return res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.CREATE_GROUP_FAIL));
+      return res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(
+          util.fail(
+            statusCode.INTERNAL_SERVER_ERROR,
+            responseMessage.CREATE_GROUP_FAIL,
+          ),
+        );
+    }
+  },
+  joinGroup: async (req, res) => {
+    try {
+      const { id } = req.decoded;
+      const { groupId } = req.body;
+
+      if (!groupId) {
+        return res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+      }
+
+      const checkMemberId = await groupService.checkMemberId(id);
+
+      if (checkMemberId) {
+        console.log(responseMessage.ALREADY_GROUP);
+        return res
+          .status(statusCode.BAD_REQUEST)
+          .send(
+            util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_GROUP),
+          );
+      }
+
+      const createMember = await groupService.createMember(id, groupId);
+
+      return res
+        .status(statusCode.CREATED)
+        .send(
+          util.success(statusCode.CREATED, responseMessage.JOIN_GROUP_SUCCESS),
+        );
+    } catch (error) {
+      console.log(error);
+      return res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(
+          util.fail(
+            statusCode.INTERNAL_SERVER_ERROR,
+            responseMessage.JOIN_GROUP_FAIL,
+          ),
+        );
     }
   },
 };

--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -14,7 +14,7 @@ module.exports = {
     const { groupName, maximumMemberNumber, introduction } = req.body;
 
     if (!groupName || !maximumMemberNumber || !introduction) {
-      console.log('필요한 값이 없습니다.');
+      console.log(responseMessage.NULL_VALUE);
       return res
         .status(statusCode.BAD_REQUEST)
         .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
@@ -23,7 +23,7 @@ module.exports = {
       const checkMemberId = await groupService.checkMemberId(id);
 
       if (checkMemberId) {
-        console.log('소속된 그룹이 이미 있습니다.');
+        console.log(responseMessage.ALREADY_GROUP);
         return res
           .status(statusCode.BAD_REQUEST)
           .send(
@@ -38,7 +38,7 @@ module.exports = {
       );
       const groupId = createGroup.id;
 
-      const createHostMember = await groupService.createHostMember(id, groupId);
+      const createHostMember = await groupService.createMember(id, groupId, true);
 
       return res
         .status(statusCode.CREATED)
@@ -82,7 +82,7 @@ module.exports = {
           );
       }
 
-      const createMember = await groupService.createMember(id, groupId);
+      const createMember = await groupService.createMember(id, groupId, false);
 
       return res
         .status(statusCode.CREATED)

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -33,6 +33,8 @@ module.exports = {
   CREATE_GROUP_SUCCESS: '그룹 생성 완료',
   CREATE_GROUP_FAIL: '그룹 생성 실패',
   ALREADY_GROUP: '이미 그룹에 속해 있습니다.',
+  JOIN_GROUP_SUCCESS: '그룹 참가 완료',
+  JOIN_GROUP_FAIL: '그룹 참가 실패',
 
   /* 토큰 */
   EMPTY_TOKEN: '토큰 값이 없습니다.',

--- a/routes/group.js
+++ b/routes/group.js
@@ -5,5 +5,6 @@ const groupController = require('../controller/groupController');
 const isLoggedIn = require('../middlewares/authUtil');
 
 router.post('/', isLoggedIn.checkToken, groupController.createGroup);
+router.post('/join', isLoggedIn.checkToken, groupController.joinGroup);
 
 module.exports = router;

--- a/service/groupService.js
+++ b/service/groupService.js
@@ -38,4 +38,16 @@ module.exports = {
       throw err;
     }
   },
+  createMember: async (id, groupId) => {
+    try {
+      const makeMember = await Member.create({
+        isHost: 0,
+        UserId: id,
+        GroupId: groupId,
+      });
+      return makeMember;
+    } catch (err) {
+      throw err;
+    }
+  },
 };

--- a/service/groupService.js
+++ b/service/groupService.js
@@ -26,22 +26,10 @@ module.exports = {
       throw err;
     }
   },
-  createHostMember: async (id, groupId) => {
-    try {
-      const makeHostMember = await Member.create({
-        isHost: 1,
-        UserId: id,
-        GroupId: groupId,
-      });
-      return makeHostMember;
-    } catch (err) {
-      throw err;
-    }
-  },
-  createMember: async (id, groupId) => {
+  createMember: async (id, groupId, isHost) => {
     try {
       const makeMember = await Member.create({
-        isHost: 0,
+        isHost,
         UserId: id,
         GroupId: groupId,
       });


### PR DESCRIPTION
## 작업사항

</br>
<div style="margin:0 auto;">
<img src="https://user-images.githubusercontent.com/59385491/103481576-43993980-4e1f-11eb-8e28-8056038daff3.png" height=400>
<img src="https://user-images.githubusercontent.com/59385491/103481589-4d22a180-4e1f-11eb-9040-f1767a0d960d.png" height=400>
<img src="https://user-images.githubusercontent.com/59385491/103481597-5875cd00-4e1f-11eb-910f-e1c306f8d02c.png" height=400>
</div>

- 그룹 참가를 요청하는 API를 구현했습니다.
- 서비스 로직의 경우, 관리자(Host)로서 그룹에 참가시키는 API를 리팩토링하여 관리자, 일반 참가자 상관 없이 사용 할 수 있도록 하였습니다. [커밋 내역 확인하기](https://github.com/nneaning/meaning_Server/commit/cf0a3c6ac668b8a2a451cf6b05b2b1146f2a7c50)

## 변경로직

## 사용방법

- 헤더와 바디를 필요로합니다. 따라서 [명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EC%B0%B8%EA%B0%80-%EC%8B%A0%EC%B2%AD)를 참고 부탁드립니다.

### 희망 리뷰 완료일

2021-01-07

### 관계된 이슈, PR 

#35 