### PR TITLE
[feat]: 타임스탬프 작성 API, 그룹 이용자용

### DIFF
--- a/controller/timeStampController.js
+++ b/controller/timeStampController.js
@@ -9,7 +9,7 @@ const dateTimeModule = require('../modules/dateTimeModule');
 const userService = require('../service/userService');
 const postService = require('../service/postService');
 const timeStampService = require('../service/timeStampService');
-const { LoopDetected } = require('http-errors');
+const groupService = require('../service/groupService');
 
 module.exports = {
   createTimeStamp: async (req, res) => {
@@ -17,7 +17,7 @@ module.exports = {
       const userId = req.decoded.id;
       const wakeUpTime = await userService.getWakeUpTime(userId);
       const timeStampImageUrl = req.file.location;
-      const { dateTime, timeStampContents, groupId } = req.body;
+      const { dateTime, timeStampContents } = req.body;
 
       if (!dateTime || !timeStampContents || !timeStampImageUrl) {
         return res
@@ -73,6 +73,7 @@ module.exports = {
         missionStatusMessage,
       };
 
+      const { GroupId: groupId } = await groupService.checkMemberId(userId);
       if (groupId) {
         const post = await postService.createPost(timeStamp.id, groupId);
         dto.postedOnGroup = true;

--- a/controller/timeStampController.js
+++ b/controller/timeStampController.js
@@ -7,7 +7,9 @@ const { dayjs } = require('../modules/dateTimeModule');
 const dateTimeModule = require('../modules/dateTimeModule');
 
 const userService = require('../service/userService');
+const postService = require('../service/postService');
 const timeStampService = require('../service/timeStampService');
+const { LoopDetected } = require('http-errors');
 
 module.exports = {
   createTimeStamp: async (req, res) => {
@@ -15,7 +17,7 @@ module.exports = {
       const userId = req.decoded.id;
       const wakeUpTime = await userService.getWakeUpTime(userId);
       const timeStampImageUrl = req.file.location;
-      const { dateTime, timeStampContents } = req.body;
+      const { dateTime, timeStampContents, groupId } = req.body;
 
       if (!dateTime || !timeStampContents || !timeStampImageUrl) {
         return res
@@ -66,16 +68,25 @@ module.exports = {
         timeStampContents,
       );
 
+      const dto = {
+        timeStampId: timeStamp.id,
+        missionStatusMessage,
+      };
+
+      if (groupId) {
+        const post = await postService.createPost(timeStamp.id, groupId);
+        dto.postedOnGroup = true;
+      } else {
+        dto.postedOnGroup = false;
+      }
+
       return res
         .status(statusCode.OK)
         .send(
           util.success(
             statusCode.OK,
             responseMessage.CREATE_TIMESTAMP_SUCCESS,
-            {
-              timeStampId: timeStamp.id,
-              missionStatusMessage,
-            },
+            dto,
           ),
         );
     } catch (error) {

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -29,6 +29,9 @@ module.exports = {
   READ_TIMESTAMP_ALL_FAIL: '전체 타임스탬프 조회 실패',
   INVALID_DATETIME_FORMAT: '유효하지 않은 날짜, 시간 정보 포맷입니다',
 
+  /* 포스트 */
+  CREATE_POST_SUCCESS: '그룹에 타임스탬프가 포스팅되었습니다.',
+
   /* 그룹 */
   CREATE_GROUP_SUCCESS: '그룹 생성 완료',
   CREATE_GROUP_FAIL: '그룹 생성 실패',

--- a/service/postService.js
+++ b/service/postService.js
@@ -1,0 +1,15 @@
+const { Post } = require('../models');
+
+module.exports = {
+  createPost: async (timeStampId, groupId) => {
+    try {
+      const post = await Post.create({
+        TimeStampId: timeStampId,
+        GroupId: groupId,
+      });
+      return post;
+    } catch (error) {
+      throw error;
+    }
+  },
+};


### PR DESCRIPTION
- 요청시,  body에 groupId를 키로 그룹의 id를 선택적으로 기입할 수 있습니다.
- 기입한 경우, 그룹의 피드로 타임스탬프를 포스팅합니다.

related to #9, #41

## 작업사항

- 기존의 타임스탬프 작성 로직 위에 Post 객체 생성 로직을 추가하여, 그룹 피드에 타임스탬프 포스팅을 구현했습니다.

## 사용방법

- [API 명세서](https://github.com/nneaning/meaning_Server/wiki/%ED%83%80%EC%9E%84%EC%8A%A4%ED%83%AC%ED%94%84-%EC%9E%91%EC%84%B1)

### 희망 리뷰 완료일

2021-01-08

### 관계된 이슈, PR 

#9, #41 