### PR TITLE
[feat]: 오늘 하루 다짐 작성 및 제공 API

### DIFF
--- a/controller/userController.js
+++ b/controller/userController.js
@@ -9,6 +9,8 @@ const statusCode = require('../modules/statusCode');
 
 const dateTimeModule = require('../modules/dateTimeModule');
 
+const { dayjs } = dateTimeModule;
+
 const userService = require('../service/userService');
 
 module.exports = {
@@ -117,8 +119,7 @@ module.exports = {
 
       let successDays = 0;
 
-      getMySuccessDay.forEach((day) =>
-        (successDays += day.status));
+      getMySuccessDay.forEach(day => (successDays += day.status));
 
       return res
         .status(statusCode.OK)
@@ -155,7 +156,12 @@ module.exports = {
       if (!dateTimeModule.checkValidTimeFormat(wakeUpTime)) {
         res
           .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.INVALID_TIME_FORMAT));
+          .send(
+            util.fail(
+              statusCode.BAD_REQUEST,
+              responseMessage.INVALID_TIME_FORMAT,
+            ),
+          );
       }
 
       const user = await userService.updateOnboard(id, nickName, wakeUpTime);
@@ -163,13 +169,21 @@ module.exports = {
       if (!user) {
         res
           .status(statusCode.INTERNAL_SERVER_ERROR)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.UPDATE_ONBOARD_FAIL));
+          .send(
+            util.fail(
+              statusCode.BAD_REQUEST,
+              responseMessage.UPDATE_ONBOARD_FAIL,
+            ),
+          );
       }
 
       return res
         .status(statusCode.OK)
         .send(
-          util.success(statusCode.NO_CONTENT, responseMessage.UPDATE_ONBOARD_SUCCESS),
+          util.success(
+            statusCode.NO_CONTENT,
+            responseMessage.UPDATE_ONBOARD_SUCCESS,
+          ),
         );
     } catch (error) {
       console.log(error);
@@ -196,30 +210,53 @@ module.exports = {
       if (!dateTimeModule.checkValidDateFormat(date)) {
         res
           .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.INVALID_DATE_FORMAT));
+          .send(
+            util.fail(
+              statusCode.BAD_REQUEST,
+              responseMessage.INVALID_DATE_FORMAT,
+            ),
+          );
       }
 
-      const checkDailyMaximContents = await userService.checkDailyMaximContents(todaysPromiseContents);
+      const checkDailyMaximContents = await userService.checkDailyMaximContents(
+        todaysPromiseContents,
+      );
 
       if (checkDailyMaximContents) {
         res
           .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_DAILYMAXIM_CONTENTS));
+          .send(
+            util.fail(
+              statusCode.BAD_REQUEST,
+              responseMessage.ALREADY_DAILYMAXIM_CONTENTS,
+            ),
+          );
       }
 
-      const checkDailyMaximDate = await userService.checkDailyMaximDate(date);
+      const checkDailyMaximDate = await userService.getDailyMaximByDate(date);
 
       if (checkDailyMaximDate) {
         res
           .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_DAILYMAXIM_DATE));
+          .send(
+            util.fail(
+              statusCode.BAD_REQUEST,
+              responseMessage.ALREADY_DAILYMAXIM_DATE,
+            ),
+          );
       }
 
-      const dailyMaxim = await userService.createDailyMaxim(todaysPromiseContents, date);
+      const dailyMaxim = await userService.createDailyMaxim(
+        todaysPromiseContents,
+        date,
+      );
       return res
         .status(statusCode.CREATED)
         .send(
-          util.success(statusCode.CREATED, responseMessage.CREATE_DAILYMAXIM_SUCCESS),
+          util.success(
+            statusCode.CREATED,
+            responseMessage.CREATE_DAILYMAXIM_SUCCESS,
+          ),
         );
     } catch (error) {
       console.log(error);

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -199,12 +199,20 @@ module.exports = {
           .send(util.fail(statusCode.BAD_REQUEST, responseMessage.INVALID_DATE_FORMAT));
       }
 
-      const checkDailyMaxim = await userService.checkDailyMaxim(todaysPromiseContents);
+      const checkDailyMaximContents = await userService.checkDailyMaximContents(todaysPromiseContents);
 
-      if (checkDailyMaxim) {
+      if (checkDailyMaximContents) {
         res
           .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_DAILYMAXIM));
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_DAILYMAXIM_CONTENTS));
+      }
+
+      const checkDailyMaximDate = await userService.checkDailyMaximDate(date);
+
+      if (checkDailyMaximDate) {
+        res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_DAILYMAXIM_DATE));
       }
 
       const dailyMaxim = await userService.createDailyMaxim(todaysPromiseContents, date);

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -270,4 +270,30 @@ module.exports = {
         );
     }
   },
+  getDailyMaxim: async (req, res) => {
+    try {
+      const date = dayjs().format(dateTimeModule.FORMAT_DATE);
+      console.log(date);
+      const dailyMaxim = await userService.getDailyMaximByDate(date);
+
+      return res
+        .status(statusCode.OK)
+        .send(
+          util.success(
+            statusCode.OK,
+            responseMessage.READ_DAILYMAXIM_SUCCESS,
+            { contents: dailyMaxim.todaysPromiseContents },
+          ),
+        );
+    } catch (error) {
+      res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(
+          util.fail(
+            statusCode.INTERNAL_SERVER_ERROR,
+            responseMessage.READ_DAILYMAXIM_FAIL,
+          ),
+        );
+    }
+  },
 };

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -185,13 +185,20 @@ module.exports = {
   },
   createDailyMaxim: async (req, res) => {
     try {
-      const { todaysPromiseContents } = req.body;
+      const { todaysPromiseContents, date } = req.body;
 
       if (!todaysPromiseContents) {
         res
           .status(statusCode.BAD_REQUEST)
           .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
       }
+
+      if (!dateTimeModule.checkValidDateFormat(date)) {
+        res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.INVALID_DATE_FORMAT));
+      }
+
       const checkDailyMaxim = await userService.checkDailyMaxim(todaysPromiseContents);
 
       if (checkDailyMaxim) {

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -207,7 +207,7 @@ module.exports = {
           .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_DAILYMAXIM));
       }
 
-      const dailyMaxim = await userService.createDailyMaxim(todaysPromiseContents);
+      const dailyMaxim = await userService.createDailyMaxim(todaysPromiseContents, date);
       return res
         .status(statusCode.CREATED)
         .send(

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable no-return-assign */
 /* eslint-disable max-len */
 const jwt = require('../modules/jwt');
@@ -178,6 +179,41 @@ module.exports = {
           util.fail(
             statusCode.INTERNAL_SERVER_ERROR,
             responseMessage.UPDATE_FAIL,
+          ),
+        );
+    }
+  },
+  createDailyMaxim: async (req, res) => {
+    try {
+      const { todaysPromiseContents } = req.body;
+
+      if (!todaysPromiseContents) {
+        res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+      }
+      const checkDailyMaxim = await userService.checkDailyMaxim(todaysPromiseContents);
+
+      if (checkDailyMaxim) {
+        res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_DAILYMAXIM));
+      }
+
+      const dailyMaxim = await userService.createDailyMaxim(todaysPromiseContents);
+      return res
+        .status(statusCode.CREATED)
+        .send(
+          util.success(statusCode.CREATED, responseMessage.CREATE_DAILYMAXIM_SUCCESS),
+        );
+    } catch (error) {
+      console.log(error);
+      res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(
+          util.fail(
+            statusCode.INTERNAL_SERVER_ERROR,
+            responseMessage.CREATE_DAILYMAXIM_FAIL,
           ),
         );
     }

--- a/models/todaysPromise.js
+++ b/models/todaysPromise.js
@@ -6,10 +6,14 @@ module.exports = (sequelize, DataTypes) =>
         type: DataTypes.STRING(200),
         allowNull: false,
       },
+      date: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
     },
     {
       underscored: false,
       freezeTableName: true,
-      timestamps: true,
+      timestamps: false,
     },
   );

--- a/modules/dateTimeModule.js
+++ b/modules/dateTimeModule.js
@@ -5,6 +5,8 @@ dayjs.extend(require('dayjs/plugin/duration'));
 
 const timeFormatRegularExpression = /(2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]/g;
 
+const FORMAT_DATE = 'YYYY-MM-DD';
+
 module.exports = {
   dayjs,
   FORMAT_TIME: 'hh:mm:ss',
@@ -12,6 +14,8 @@ module.exports = {
   FORMAT_DATE: 'YYYY-MM-DD',
   checkValidDateTimeFormat: (dateTimeString) =>
     dayjs(dateTimeString, this.DATETIME).isValid(),
+  checkValidDateFormat: (dateString) =>
+    dayjs(dateString, FORMAT_DATE, true).isValid(),
   checkValidTimeFormat: (timeString) =>
     timeFormatRegularExpression.test(timeString),
   getTimeDifference: (dateTimeFrom, dateTimeTo) =>

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -38,7 +38,8 @@ module.exports = {
   CREATE_DAILYMAXIM_FAIL: '오늘 하루 다짐 생성 실패',
   READ_DAILYMAXIM_SUCCESS: '오늘 하루 다짐 조회 완료',
   READ_DAILYMAXIM_FAIL: '오늘 하루 다짐 조회 실패',
-  ALREADY_DAILYMAXIM: '이미 존재하는 오늘 하루 다짐 입니다.',
+  ALREADY_DAILYMAXIM_CONTENTS: '이미 존재하는 오늘 하루 다짐 문구 입니다.',
+  ALREADY_DAILYMAXIM_DATE: '해당 날짜에 보여줄 오늘 하루 다짐은 이미 존재합니다.',
 
   /* 게시글 */
   READ_POST_ALL_SUCCESS: '전체 게시글 조회 성공',

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -14,7 +14,6 @@ module.exports = {
   /* 온보드 정보 등록 */
   UPDATE_ONBOARD_SUCCESS: '온보드 정보 등록 성공',
   UPDATE_ONBOARD_FAIL: '온보드 정보 등록 실패',
-  INVALID_TIME_FORMAT: '유효하지 않은 시간 정보 포맷입니다.',
 
   /* 회원관리 */
   ALREADY_ID: '존재하는 ID 입니다.',
@@ -28,7 +27,11 @@ module.exports = {
   CREATE_TIMESTAMP_FAIL: '타임스탬프 생성 실패',
   READ_TIMESTAMP_ALL_SUCCESS: '전체 타임스탬프 조회 성공',
   READ_TIMESTAMP_ALL_FAIL: '전체 타임스탬프 조회 실패',
+
+  /* 시간, 날짜 포맷 */
   INVALID_DATETIME_FORMAT: '유효하지 않은 날짜, 시간 정보 포맷입니다',
+  INVALID_TIME_FORMAT: '유효하지 않은 시간 정보 포맷입니다.',
+  INVALID_DATE_FORMAT: '유효하지 않은 날짜 정보 포맷입니다.',
 
   /* 오늘 하루 다짐 */
   CREATE_DAILYMAXIM_SUCCESS: '오늘 하루 다짐 생성 완료',

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -30,11 +30,17 @@ module.exports = {
   READ_TIMESTAMP_ALL_FAIL: '전체 타임스탬프 조회 실패',
   INVALID_DATETIME_FORMAT: '유효하지 않은 날짜, 시간 정보 포맷입니다',
 
+  /* 오늘 하루 다짐 */
+  CREATE_DAILYMAXIM_SUCCESS: '오늘 하루 다짐 생성 완료',
+  CREATE_DAILYMAXIM_FAIL: '오늘 하루 다짐 생성 실패',
+  READ_DAILYMAXIM_SUCCESS: '오늘 하루 다짐 조회 완료',
+  READ_DAILYMAXIM_FAIL: '오늘 하루 다짐 조회 실패',
+  ALREADY_DAILYMAXIM: '이미 존재하는 오늘 하루 다짐 입니다.',
 
   /* 게시글 */
   READ_POST_ALL_SUCCESS: '전체 게시글 조회 성공',
   READ_POST_ALL_FAIL: '전체 게시글 조회 실패',
-  
+
   /* 포스트 */
   CREATE_POST_SUCCESS: '그룹에 타임스탬프가 포스팅되었습니다.',
 

--- a/routes/user.js
+++ b/routes/user.js
@@ -11,6 +11,8 @@ router.put('/refreshtoken', isLoggedIn.reIssue);
 
 router.put('/onboard', isLoggedIn.checkToken, userController.updateOnboard);
 
+router.post('/daypromise', userController.createDailyMaxim);
+
 router.get('/mypage', isLoggedIn.checkToken, userController.getMyPage);
 
 module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -11,6 +11,7 @@ router.put('/refreshtoken', isLoggedIn.reIssue);
 
 router.put('/onboard', isLoggedIn.checkToken, userController.updateOnboard);
 
+router.get('/daypromise', isLoggedIn.checkToken, userController.getDailyMaxim);
 router.post('/daypromise', userController.createDailyMaxim);
 
 router.get('/mypage', isLoggedIn.checkToken, userController.getMyPage);

--- a/service/postService.js
+++ b/service/postService.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-catch */
 const { Post } = require('../models');
 
 module.exports = {

--- a/service/userService.js
+++ b/service/userService.js
@@ -132,10 +132,11 @@ module.exports = {
       throw err;
     }
   },
-  createDailyMaxim: async (todaysPromiseContents) => {
+  createDailyMaxim: async (todaysPromiseContents, date) => {
     try {
       const dailyMaxim = await TodaysPromise.create({
         todaysPromiseContents,
+        date,
       });
       return dailyMaxim;
     } catch (err) {

--- a/service/userService.js
+++ b/service/userService.js
@@ -143,11 +143,23 @@ module.exports = {
       throw err;
     }
   },
-  checkDailyMaxim: async (todaysPromiseContents) => {
+  checkDailyMaximContents: async (todaysPromiseContents) => {
     try {
       const alreadyDailyMaxim = await TodaysPromise.findOne({
         where: {
           todaysPromiseContents,
+        },
+      });
+      return alreadyDailyMaxim;
+    } catch (err) {
+      throw err;
+    }
+  },
+  checkDailyMaximDate: async (date) => {
+    try {
+      const alreadyDailyMaxim = await TodaysPromise.findOne({
+        where: {
+          date,
         },
       });
       return alreadyDailyMaxim;

--- a/service/userService.js
+++ b/service/userService.js
@@ -155,14 +155,14 @@ module.exports = {
       throw err;
     }
   },
-  checkDailyMaximDate: async (date) => {
+  getDailyMaximByDate: async (date) => {
     try {
-      const alreadyDailyMaxim = await TodaysPromise.findOne({
+      const dailyMaxim = await TodaysPromise.findOne({
         where: {
           date,
         },
       });
-      return alreadyDailyMaxim;
+      return dailyMaxim;
     } catch (err) {
       throw err;
     }

--- a/service/userService.js
+++ b/service/userService.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-useless-catch */
 
 const crypto = require('crypto');
-const { User, TimeStamp } = require('../models');
+const { User, TimeStamp, TodaysPromise } = require('../models');
 
 module.exports = {
   checkEmail: async (email) => {
@@ -128,6 +128,28 @@ module.exports = {
         },
       );
       return user;
+    } catch (err) {
+      throw err;
+    }
+  },
+  createDailyMaxim: async (todaysPromiseContents) => {
+    try {
+      const dailyMaxim = await TodaysPromise.create({
+        todaysPromiseContents,
+      });
+      return dailyMaxim;
+    } catch (err) {
+      throw err;
+    }
+  },
+  checkDailyMaxim: async (todaysPromiseContents) => {
+    try {
+      const alreadyDailyMaxim = await TodaysPromise.findOne({
+        where: {
+          todaysPromiseContents,
+        },
+      });
+      return alreadyDailyMaxim;
     } catch (err) {
       throw err;
     }


### PR DESCRIPTION
## 작업사항

[이슈](https://github.com/nneaning/meaning_Server/issues/46)

- 오늘 하루 다짐 데이터를 저장하는 API입니다. 
- todaysPromiseContents을 body값으로 받습니다.
- 미리 데이터를 넣고, GET방식으로 데이터를 제공할 땐, User에 연결하는 방식을 앞으로 고안해야합니다.

## 사용방법

- URL과 헤더를 통해 파라미터를 받습니다. 명세서를 참고 부탁드립니다.
- [명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EB%82%B4%EB%B6%80-%ED%94%BC%EB%93%9C)

### 희망 리뷰 완료일

2021-01-10

### 관계된 이슈, PR 

- #46 
- #47
