### PR TITLE
[feet] 그룹 설정 정보 제공 API

### DIFF
--- a/controller/timeStampController.js
+++ b/controller/timeStampController.js
@@ -41,9 +41,8 @@ module.exports = {
           );
       }
 
-      const targetTime = dayjs(`${dayjs().format(dateTimeModule.FORMAT_DATE)} ${wakeUpTime}`);
-      const requestedTime = dayjs(dateTime);
-      const timeDifference = dateTimeModule.getTimeDifference(requestedTime, targetTime);
+      const targetTime = `${dayjs().format(dateTimeModule.FORMAT_DATE)} ${wakeUpTime}`;
+      const timeDifference = dateTimeModule.getTimeDifference(dateTime, targetTime);
 
       let timeStampMissionStatus;
       if (timeDifference <= 0) {

--- a/modules/dateTimeModule.js
+++ b/modules/dateTimeModule.js
@@ -15,5 +15,7 @@ module.exports = {
   checkValidTimeFormat: (timeString) =>
     timeFormatRegularExpression.test(timeString),
   getTimeDifference: (dateTimeFrom, dateTimeTo) =>
-    dayjs.duration(dateTimeFrom.diff(dateTimeTo)).asMinutes(),
+    dayjs.duration(dayjs(dateTimeFrom).diff(dayjs(dateTimeTo))).asMinutes(),
+  getDateDifference: (dateTimeFrom, dateTimeTo) =>
+    dayjs.duration(dayjs(dateTimeFrom).diff(dayjs(dateTimeTo))).asDays(),
 };

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -34,11 +34,16 @@ module.exports = {
   CREATE_POST_SUCCESS: '그룹에 타임스탬프가 포스팅되었습니다.',
 
   /* 그룹 */
+  NO_GROUP: '존재하지 않는 그룹의 ID입니다.',
   CREATE_GROUP_SUCCESS: '그룹 생성 완료',
   CREATE_GROUP_FAIL: '그룹 생성 실패',
   ALREADY_GROUP: '이미 그룹에 속해 있습니다.',
   JOIN_GROUP_SUCCESS: '그룹 참가 완료',
   JOIN_GROUP_FAIL: '그룹 참가 실패',
+
+  /* 설정 정보 */
+  GET_GROUP_SETTING_SUCCESS: '그룹 설정 정보 불러오기 성공',
+  GET_GROUP_SETTING_FAIL: '그룹 설정 정보 불러오기 실패',
 
   /* 그룹 이미지 등록 */
   CREATE_GROUPIMAGE_SUCCESS: '그룹 이미지 등록 완료',

--- a/routes/group.js
+++ b/routes/group.js
@@ -8,5 +8,6 @@ const upload = require('../modules/multer');
 router.post('/', isLoggedIn.checkToken, groupController.createGroup);
 router.post('/upload', upload.single('image'), groupController.createGroupImage);
 router.post('/join', isLoggedIn.checkToken, groupController.joinGroup);
+router.get('/:groupId/edit', isLoggedIn.checkToken, groupController.getEditInformation);
 
 module.exports = router;

--- a/service/groupService.js
+++ b/service/groupService.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-dupe-keys */
 /* eslint-disable no-useless-catch */
 const {
-  Group, Member, GroupImage, GroupProfile,
+  Group, Member, GroupImage, GroupProfile, User,
 } = require('../models');
 
 module.exports = {
@@ -13,6 +13,17 @@ module.exports = {
         introduction,
       });
       return makeGroup;
+    } catch (err) {
+      throw err;
+    }
+  },
+  readGroup: async (id) => {
+    try {
+      return await Group.findOne({
+        where: {
+          id,
+        },
+      });
     } catch (err) {
       throw err;
     }
@@ -37,6 +48,23 @@ module.exports = {
         GroupId: groupId,
       });
       return makeMember;
+    } catch (err) {
+      throw err;
+    }
+  },
+  readAllUsers: async (groupId) => {
+    try {
+      const members = await User.findAll({
+        attributes: ['id', 'userName', 'nickName', 'wakeUpTime'],
+        include: [{
+          model: Group,
+          where: {
+            id: groupId,
+          },
+          attributes: [],
+        }],
+      });
+      return members;
     } catch (err) {
       throw err;
     }


### PR DESCRIPTION
## 작업사항

- 그룹 설정 뷰에서 필요한 정보들을 제공합니다.

## 사용방법

- [명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EC%84%A4%EC%A0%95)
- 헤더로 토큰과, URL에 조회하고자 하는 그룹의 id를 받습니다.
- 요청 URL: /group/:groupId/edit

### 희망 리뷰 완료일

2021-01-10

### 관계된 이슈, PR 

#51 