### PR TITLE
[feat]: 독후감 API 개발 추가

### DIFF
--- a/controller/userController.js
+++ b/controller/userController.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable no-return-assign */
 /* eslint-disable max-len */
 const jwt = require('../modules/jwt');
@@ -178,6 +179,42 @@ module.exports = {
           util.fail(
             statusCode.INTERNAL_SERVER_ERROR,
             responseMessage.UPDATE_FAIL,
+          ),
+        );
+    }
+  },
+  createBookComment: async (req, res) => {
+    try {
+      const { id } = req.decoded;
+      const { bookTitle, bookCommentContents } = req.body;
+
+      if (!bookTitle || !bookCommentContents) {
+        return res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+      }
+      const checkBookComment = await userService.checkBookComment(bookCommentContents);
+
+      if (checkBookComment) {
+        return res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_BOOKCOMMENT));
+      }
+
+      const bookReview = await userService.createBookComment(bookTitle, bookCommentContents, id);
+      return res
+        .status(statusCode.CREATED)
+        .send(
+          util.success(statusCode.CREATED, responseMessage.CREATE_BOOKCOMMENT_SUCCESS),
+        );
+    } catch (error) {
+      console.log(error);
+      res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(
+          util.fail(
+            statusCode.INTERNAL_SERVER_ERROR,
+            responseMessage.CREATE_BOOKCOMMENT_FAIL,
           ),
         );
     }

--- a/models/bookComment.js
+++ b/models/bookComment.js
@@ -2,6 +2,10 @@ module.exports = (sequelize, DataTypes) =>
   sequelize.define(
     'BookComment',
     {
+      bookTitle: {
+        type: DataTypes.STRING(60),
+        allowNull: false,
+      },
       bookCommentContents: {
         type: DataTypes.STRING(200),
         allowNull: false,

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -30,11 +30,15 @@ module.exports = {
   READ_TIMESTAMP_ALL_FAIL: '전체 타임스탬프 조회 실패',
   INVALID_DATETIME_FORMAT: '유효하지 않은 날짜, 시간 정보 포맷입니다',
 
+  /* 독서록 */
+  CREATE_BOOKCOMMENT_SUCCESS: '독후감 생성 완료',
+  CREATE_BOOKCOMMENT_FAIL: '독후감 생성 실패',
+  ALREADY_BOOKCOMMENT: '이미 독후감이 작성됐습니다.',
 
   /* 게시글 */
   READ_POST_ALL_SUCCESS: '전체 게시글 조회 성공',
   READ_POST_ALL_FAIL: '전체 게시글 조회 실패',
-  
+
   /* 포스트 */
   CREATE_POST_SUCCESS: '그룹에 타임스탬프가 포스팅되었습니다.',
 

--- a/routes/user.js
+++ b/routes/user.js
@@ -12,5 +12,6 @@ router.put('/refreshtoken', isLoggedIn.reIssue);
 router.put('/onboard', isLoggedIn.checkToken, userController.updateOnboard);
 
 router.get('/mypage', isLoggedIn.checkToken, userController.getMyPage);
+router.post('/bookreview', isLoggedIn.checkToken, userController.createBookComment);
 
 module.exports = router;

--- a/service/postService.js
+++ b/service/postService.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-catch */
 const { Post } = require('../models');
 
 module.exports = {

--- a/service/userService.js
+++ b/service/userService.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-useless-catch */
 
 const crypto = require('crypto');
-const { User, TimeStamp } = require('../models');
+const { User, TimeStamp, BookComment } = require('../models');
 
 module.exports = {
   checkEmail: async (email) => {
@@ -128,6 +128,30 @@ module.exports = {
         },
       );
       return user;
+    } catch (err) {
+      throw err;
+    }
+  },
+  createBookComment: async (bookTitle, bookCommentContents, UserId) => {
+    try {
+      const bookReview = await BookComment.create({
+        bookTitle,
+        bookCommentContents,
+        UserId,
+      });
+      return bookReview;
+    } catch (err) {
+      throw err;
+    }
+  },
+  checkBookComment: async (bookCommentContents) => {
+    try {
+      const alreadyBookReview = await BookComment.findOne({
+        where: {
+          bookCommentContents,
+        },
+      });
+      return alreadyBookReview;
     } catch (err) {
       throw err;
     }


### PR DESCRIPTION
## 작업사항

[이슈](https://github.com/nneaning/meaning_Server/issues/50)

- 자기회고 및 일기를 작성하는 API입니다. 
- user의 id를 토큰에서 가져오고, body값으로 bookTitle, bookCommentContents를 받아서, 이를 DB에 저장합니다.

## 사용방법

- URL과 헤더를 통해 파라미터를 받습니다. 명세서를 참고 부탁드립니다.
- [명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EB%82%B4%EB%B6%80-%ED%94%BC%EB%93%9C)

### 희망 리뷰 완료일

2021-01-10

### 관계된 이슈, PR 

- #50 
