### PR TITLE
[feat]: 그룹리스트 상세보기 API

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-return-assign */
@@ -69,6 +70,39 @@ module.exports = {
         );
     }
   },
+  readGroupDetail: async (req, res) => {
+    try {
+      const { groupId } = req.params;
+
+      const checkGroupId = await groupService.readGroup(groupId);
+
+      if (!checkGroupId) {
+        console.log(responseMessage.NO_GROUP);
+        return res
+          .status(statusCode.BAD_REQUEST)
+          .send(
+            util.fail(statusCode.BAD_REQUEST, responseMessage.NO_GROUP),
+          );
+      }
+
+      const groupDetail = {
+        groupId,
+        groupName: checkGroupId.groupName,
+        introduction: checkGroupId.introduction,
+        maximumMemberNumber: checkGroupId.maximumMemberNumber,
+        countMember: await groupService.countMember(groupId),
+      };
+      return res
+        .status(statusCode.OK)
+        .send(
+          util.success(statusCode.OK, responseMessage.GET_GROUP_DETAIL_SUCCESS, { groupDetail }),
+        );
+    } catch (error) {
+      console.log(error);
+      return res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.GET_GROUP_DETAIL_FAIL));
+    }
+  },
+
   joinGroup: async (req, res) => {
     try {
       const { id } = req.decoded;
@@ -147,7 +181,7 @@ module.exports = {
         );
     }
   },
- readAllPost: async (req, res) => {
+  readAllPost: async (req, res) => {
     try {
       const { groupId } = req.params;
       const { offset } = req.query;
@@ -193,7 +227,9 @@ module.exports = {
           .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_GROUP));
       }
 
-      const group = { groupId, groupName, introduction, maximumMemberNumber };
+      const group = {
+        groupId, groupName, introduction, maximumMemberNumber,
+      };
 
       const users = await groupService.readAllUsers(groupId);
       for (const { dataValues } of users) {

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -1,3 +1,4 @@
+/* eslint-disable arrow-parens */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-return-assign */
 /* eslint-disable max-len */
@@ -119,7 +120,8 @@ module.exports = {
 
       let successDays = 0;
 
-      getMySuccessDay.forEach(day => (successDays += day.status));
+      getMySuccessDay.forEach(day =>
+        (successDays += day.status));
 
       return res
         .status(statusCode.OK)
@@ -319,7 +321,7 @@ module.exports = {
         .status(statusCode.CREATED)
         .send(
           util.success(statusCode.CREATED, responseMessage.CREATE_BOOKCOMMENT_SUCCESS),
-      );
+        );
     } catch (error) {
       console.log(error);
       res
@@ -328,7 +330,7 @@ module.exports = {
           util.fail(
             statusCode.INTERNAL_SERVER_ERROR,
             responseMessage.CREATE_BOOKCOMMENT_FAIL,
-            ),
+          ),
         );
     }
   },
@@ -367,5 +369,5 @@ module.exports = {
           ),
         );
     }
-  },  
+  },
 };

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -60,6 +60,10 @@ module.exports = {
   JOIN_GROUP_SUCCESS: '그룹 참가 완료',
   JOIN_GROUP_FAIL: '그룹 참가 실패',
 
+  /* 그룹 상세정보 */
+  GET_GROUP_DETAIL_SUCCESS: '그룹 상세보기 정보 불러오기 성공',
+  GET_GROUP_DETAIL_FAIL: '그룹 상세보기 정보 불러오기 실패',
+
   /* 설정 정보 */
   GET_GROUP_SETTING_SUCCESS: '그룹 설정 정보 불러오기 성공',
   GET_GROUP_SETTING_FAIL: '그룹 설정 정보 불러오기 실패',

--- a/routes/group.js
+++ b/routes/group.js
@@ -6,6 +6,7 @@ const isLoggedIn = require('../middlewares/authUtil');
 const upload = require('../modules/multer');
 
 router.post('/', isLoggedIn.checkToken, groupController.createGroup);
+router.get('/:groupId', isLoggedIn.checkToken, groupController.readGroupDetail);
 router.post('/upload', upload.single('image'), groupController.createGroupImage);
 router.post('/join', isLoggedIn.checkToken, groupController.joinGroup);
 router.get('/:groupId/edit', isLoggedIn.checkToken, groupController.getEditInformation);

--- a/routes/user.js
+++ b/routes/user.js
@@ -18,5 +18,4 @@ router.get('/mypage', isLoggedIn.checkToken, userController.getMyPage);
 router.post('/dailydiary', isLoggedIn.checkToken, userController.createDailyDiary);
 router.post('/bookreview', isLoggedIn.checkToken, userController.createBookComment);
 
-
 module.exports = router;

--- a/service/groupService.js
+++ b/service/groupService.js
@@ -130,4 +130,16 @@ module.exports = {
       throw error;
     }
   },
+  countMember: async (id) => {
+    try {
+      const countMember = await Member.findAll({
+        where: {
+          GroupId: id,
+        },
+      });
+      return countMember.length;
+    } catch (err) {
+      throw err;
+    }
+  },
 };

--- a/service/userService.js
+++ b/service/userService.js
@@ -2,8 +2,9 @@
 /* eslint-disable no-useless-catch */
 
 const crypto = require('crypto');
-const { User, TimeStamp, TodaysPromise, BookComment, Diary } = require('../models');
-
+const {
+  User, TimeStamp, TodaysPromise, BookComment, Diary,
+} = require('../models');
 
 module.exports = {
   checkEmail: async (email) => {


### PR DESCRIPTION
## 작업사항

[이슈](https://github.com/nneaning/meaning_Server/issues/24)

- 그룹의 상세정보를 제공하는 API입니다. 
- params값으로 groupId를 받고, 이 데이터를 활용해 그룹의 상세 정보를 제공합니다.

## 사용방법

- URL과 헤더를 통해 파라미터를 받습니다. 명세서를 참고 부탁드립니다.
- [명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EC%83%81%EC%84%B8%EB%B3%B4%EA%B8%B0)

### 희망 리뷰 완료일

- 2021-01-11

### 관계된 이슈, PR 

- #24
