### PR TITLE
[fix]: 로그인 API 닉네임과 기상시간 제공하는 로직 추가

### DIFF
--- a/controller/userController.js
+++ b/controller/userController.js
@@ -94,6 +94,8 @@ module.exports = {
         util.success(statusCode.OK, responseMessage.SIGN_IN_SUCCESS, {
           accessToken,
           refreshToken,
+          nickName: checkEmail.nickName,
+          wakeUpTime: checkEmail.wakeUpTime,
         }),
       );
     } catch (error) {


### PR DESCRIPTION
## 작업사항

[이슈](https://github.com/nneaning/meaning_Server/issues/10)

- 로그인 API입니다. 
- 기존 로그인 로직에서 유저의 닉네임과 기상시간을 제공하는 로직으로 변경했습니다.

## 사용방법

- [명세서](https://github.com/nneaning/meaning_Server/wiki/%EB%A1%9C%EA%B7%B8%EC%9D%B8)

### 희망 리뷰 완료일

- 2021-01-11

### 관계된 이슈, PR 

- #10 
