### PR TITLE
[feat]: 그룹 생성시 생성된 그룹의 id 응답

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -61,11 +61,13 @@ module.exports = {
       );
 
       return res
-        .status(statusCode.CREATED)
+        .status(statusCode.OK)
         .send(
           util.success(
             statusCode.CREATED,
-            responseMessage.CREATE_GROUP_SUCCESS,
+            responseMessage.CREATE_GROUP_SUCCESS, {
+              groupId,
+            },
           ),
         );
     } catch (error) {


### PR DESCRIPTION
## 작업사항

- 그룹을 생성할 경우, 응답 바디에 그룹Id를 첨부합니다.
- related to #31 

### 변경전

ex
```
{
    "status": 201,
    "success": true,
    "message": "그룹 생성 완료"
}
```

### 변경후
```
{
    "status": 201,
    "success": true,
    "message": "그룹 생성 완료",
    "data": {
        "groupId": 43
    }
}
```
## 사용방법

- [명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EC%83%9D%EC%84%B1)

### 희망 리뷰 완료일

2021-01-11

### 관계된 이슈, PR 
#31 