### PR TITLE
[fix]: 일기 작성 API 응답 문구 변경 및 내용 검증 로직 삭제

### DIFF
--- a/controller/userController.js
+++ b/controller/userController.js
@@ -346,19 +346,14 @@ module.exports = {
           .status(statusCode.BAD_REQUEST)
           .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
       }
-      const checkDailyDiary = await userService.checkDailyDiary(diaryContents);
-
-      if (checkDailyDiary) {
-        return res
-          .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_DAILYMAXIM));
-      }
 
       const dailyDiary = await userService.createDailyDiary(diaryContents, id);
       return res
         .status(statusCode.CREATED)
         .send(
-          util.success(statusCode.CREATED, responseMessage.CREATE_DAILYMAXIM_SUCCESS),
+          util.success(statusCode.CREATED, responseMessage.CREATE_DAILYDIARY_SUCCESS, {
+            dailyDiaryId: dailyDiary.id,
+          }),
         );
     } catch (error) {
       console.log(error);
@@ -367,7 +362,7 @@ module.exports = {
         .send(
           util.fail(
             statusCode.INTERNAL_SERVER_ERROR,
-            responseMessage.CREATE_DAILYMAXIM_FAIL,
+            responseMessage.CREATE_DAILYDIARY_FAIL,
           ),
         );
     }

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -46,6 +46,10 @@ module.exports = {
   ALREADY_DAILYMAXIM_CONTENTS: '이미 존재하는 오늘 하루 다짐 문구 입니다.',
   ALREADY_DAILYMAXIM_DATE: '이미 오늘 하루 다짐 문구가 등록된 날짜입니다.',
 
+  /* 자기 회고 및 일기 */
+  CREATE_DAILYDIARY_SUCCESS: '일기 작성 완료',
+  CREATE_DAILYDIARY_FAIL: '일기 작성 실패',
+
   /* 게시글 */
   READ_POST_ALL_SUCCESS: '전체 게시글 조회 성공',
   READ_POST_ALL_FAIL: '전체 게시글 조회 실패',


### PR DESCRIPTION
## 작업사항

- 일기 작성 시 하루 다짐 레이어의 응답 메세지가 첨부되는 것을 수정했습니다.
- 내용의 중복을 검사하는 로직이 있었습니다. 일기는 내용이 중복되어도 상관 없기에 삭제했습니다.

### 희망 리뷰 완료일

2021-01-11

### 관계된 이슈, PR 

related to #49