### PR TITLE
[fix]: 온보드 등록시 시간 포맷 검증에서의 불안정성 해결

### DIFF
--- a/modules/dateTimeModule.js
+++ b/modules/dateTimeModule.js
@@ -3,11 +3,14 @@ const dayjs = require('dayjs');
 dayjs.extend(require('dayjs/plugin/customParseFormat'));
 dayjs.extend(require('dayjs/plugin/duration'));
 
-const timeFormatRegularExpression = /(2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]/g;
-
 const FORMAT_DATE = 'YYYY-MM-DD';
 const FORMAT_TIME = 'HH:mm:ss';
 const FORMAT_DATETIME = 'YYYY-MM-DD HH:mm:ss';
+
+function checkValidTimeFormat(timeString) {
+  const tempDateTime = `${dayjs().format(FORMAT_DATE)} ${timeString}`;
+  return dayjs(tempDateTime, FORMAT_DATETIME, true).isValid();
+}
 
 module.exports = {
   dayjs,
@@ -18,8 +21,7 @@ module.exports = {
     dayjs(dateTimeString, FORMAT_DATETIME, true).isValid(),
   checkValidDateFormat: (dateString) =>
     dayjs(dateString, FORMAT_DATE, true).isValid(),
-  checkValidTimeFormat: (timeString) =>
-    timeFormatRegularExpression.test(timeString),
+  checkValidTimeFormat,
   getTimeDifference: (dateTimeFrom, dateTimeTo) =>
     dayjs.duration(dayjs(dateTimeFrom).diff(dayjs(dateTimeTo))).asMinutes(),
   getDateDifference: (dateTimeFrom, dateTimeTo) =>


### PR DESCRIPTION
## 작업사항

- 원인은 알 수 없으나, 정규표현식의 검증 메소드(:regularExpressionObejct.test(String))가 불안정한 현상이 있었습니다.
- 제대로 된 시간 포맷 'HH:mm:ss'를 맞추어 보내도, 불규칙적으로 검증을 통과하거나 그러지 못하는 현상이 반복되었습니다.
- 따라서 검증시 dayjs 라이브러리를 사용하도록 대체합니다.

### 변경전

```
checkValidTimeFormat: (timeString) =>
    timeFormatRegularExpression.test(timeString),
```
### 변경후
```
function checkValidTimeFormat(timeString) {
  const tempDateTime = `${dayjs().format(FORMAT_DATE)} ${timeString}`;
  return dayjs(tempDateTime, FORMAT_DATETIME, true).isValid();
}
```

### 희망 리뷰 완료일

2021-01-12

### 관계된 이슈, PR ****