### PR TITLE
[refactor]: 그룹 내부 피드 API 요청 URL 변경

### DIFF
--- a/routes/group.js
+++ b/routes/group.js
@@ -11,6 +11,6 @@ router.get('/:groupId', isLoggedIn.checkToken, groupController.readGroupDetail);
 router.post('/upload', upload.single('image'), groupController.createGroupImage);
 router.post('/join', isLoggedIn.checkToken, groupController.joinGroup);
 router.get('/:groupId/edit', isLoggedIn.checkToken, groupController.getEditInformation);
-router.get('/:groupId/post', isLoggedIn.checkToken, groupController.readAllPost);
+router.get('/:groupId/feed', isLoggedIn.checkToken, groupController.readAllPost);
 
 module.exports = router;


### PR DESCRIPTION
## 작업사항

- 그룹 내부 피드 화면의 API 요청 URL이 명세서와 다르게 설정되어 있어, 수정합니다.

related to #43

### 변경전

- 요청 url: group/:groupId/post?offset=:offset

### 변경후

- 요청 url: group/:groupId/feed?offset=:offset

## 사용방법

- [명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EB%82%B4%EB%B6%80-%ED%94%BC%EB%93%9C)

### 희망 리뷰 완료일

2021-01-12

### 관계된 이슈, PR 

#43