### PR TITLE
[feat] 온보드 정보 초기화(삭제)

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -288,7 +288,7 @@ module.exports = {
       if (!groupId) {
         return res
           .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_USER));
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
       }
 
       const posts = await groupService.readAllPost(

--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -288,7 +288,7 @@ module.exports = {
       if (!groupId) {
         return res
           .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_USER));
       }
 
       const posts = await groupService.readAllPost(

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -196,7 +196,42 @@ module.exports = {
         .send(
           util.fail(
             statusCode.INTERNAL_SERVER_ERROR,
-            responseMessage.UPDATE_FAIL,
+            responseMessage.UPDATE_ONBOARD_FAIL,
+          ),
+        );
+    }
+  },
+  deleteOnboard: async (req, res) => {
+    try {
+      const { id } = req.query;
+      if (!id) {
+        return res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
+      }
+
+      const checkOnboardUpdated = await userService.deleteOnboard(id);
+      if (!checkOnboardUpdated) {
+        return res
+          .status(statusCode.BAD_REQUEST)
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_USER));
+      }
+
+      return res
+        .status(statusCode.OK)
+        .send(
+          util.success(
+            statusCode.NO_CONTENT,
+            responseMessage.DELETE_ONBOARD_SUCCESS,
+          ),
+        );
+    } catch (error) {
+      return res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(
+          util.fail(
+            statusCode.INTERNAL_SERVER_ERROR,
+            responseMessage.DELETE_ONBOARD_FAIL,
           ),
         );
     }

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -14,6 +14,8 @@ module.exports = {
   /* 온보드 정보 등록 */
   UPDATE_ONBOARD_SUCCESS: '온보드 정보 등록 성공',
   UPDATE_ONBOARD_FAIL: '온보드 정보 등록 실패',
+  DELETE_ONBOARD_SUCCESS: '온보드 정보 삭제 성공',
+  DELETE_ONBOARD_FAIL: '온보드 정보 삭제 실패',
 
   /* 회원관리 */
   ALREADY_ID: '존재하는 ID 입니다.',

--- a/routes/group.js
+++ b/routes/group.js
@@ -11,6 +11,6 @@ router.get('/:groupId', isLoggedIn.checkToken, groupController.readGroupDetail);
 router.post('/upload', upload.single('image'), groupController.createGroupImage);
 router.post('/join', isLoggedIn.checkToken, groupController.joinGroup);
 router.get('/:groupId/edit', isLoggedIn.checkToken, groupController.getEditInformation);
-router.get('/:groupId/post', isLoggedIn.checkToken, groupController.readAllPost);
+router.get('/:groupId/feed', isLoggedIn.checkToken, groupController.readAllPost);
 
 module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -10,6 +10,7 @@ router.post('/signin', userController.signin);
 router.put('/refreshtoken', isLoggedIn.reIssue);
 
 router.put('/onboard', isLoggedIn.checkToken, userController.updateOnboard);
+router.delete('/onboard', userController.deleteOnboard);
 
 router.get('/daypromise', isLoggedIn.checkToken, userController.getDailyMaxim);
 router.post('/daypromise', userController.createDailyMaxim);

--- a/service/userService.js
+++ b/service/userService.js
@@ -146,6 +146,24 @@ module.exports = {
       throw err;
     }
   },
+  deleteOnboard: async (id) => {
+    try {
+      const user = await User.update(
+        {
+          nickName: null,
+          wakeUpTime: null,
+        },
+        {
+          where: {
+            id,
+          },
+        },
+      );
+      return user;
+    } catch (err) {
+      throw err;
+    }
+  },
   createBookComment: async (bookTitle, bookCommentContents, UserId) => {
     try {
       const bookReview = await BookComment.create({


### PR DESCRIPTION
## 작업사항

- 사용자 계정의 온보드 정보를 삭제합니다.
- DB의 해당 값을 null로 채워넣습니다.
- 개발 과정에서 생산성을 높이기 위해 구현하였습니다.

## 사용방법

- [명세서](https://github.com/nneaning/meaning_Server/wiki/%EC%98%A8%EB%B3%B4%EB%93%9C-%EC%82%AD%EC%A0%9C)

### 희망 리뷰 완료일

2021-01-12

### 관계된 이슈, PR 

#69 
