### PR TITLE
[fix]: 타임스탬프 작성 API 응답 오타 수정

### DIFF
--- a/controller/timeStampController.js
+++ b/controller/timeStampController.js
@@ -64,7 +64,7 @@ module.exports = {
 
       const dto = {
         timeStampId: timeStamp.id,
-        misstionStatus: timeStampMissionStatus,
+        missionStatus: timeStampMissionStatus,
       };
 
       const checkHasGroup = await groupService.checkMemberId(userId);


### PR DESCRIPTION
## 작업사항
- missionStatus가 misstionStatus로 표기되는 오타가 있어 수정합니다.

### 변경전
```
const dto = {
        timeStampId: timeStamp.id,
        misstionStatus: timeStampMissionStatus,
      };
```
### 변경후

```
const dto = {
        timeStampId: timeStamp.id,
        missionStatus: timeStampMissionStatus,
      };
```

### 희망 리뷰 완료일

2021-01-13

### 관계된 이슈, PR 