### PR TITLE
[feat]: 사용자가 가입된 그룹 정보 요청

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -146,6 +146,46 @@ module.exports = {
       return res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.READ_GROUP_ALL_FAIL));
     }
   },
+  readMyGroup: async (req, res) => {
+    try {
+      const { id } = req.decoded;
+      const checkMemberId = await groupService.checkMemberId(id);
+
+      let dto;
+      if (checkMemberId) {
+        const groupId = checkMemberId.GroupId;
+        const readGroup = await groupService.readGroup(groupId);
+        const countMember = await groupService.countMember(groupId);
+
+        dto = {
+          groupId,
+          groupName: readGroup.groupName,
+          countMember,
+          maximumMemberNumber: readGroup.maximumMemberNumber,
+        };
+      } else {
+        dto = null;
+      }
+
+      return res
+        .status(statusCode.OK)
+        .send(
+          util.success(statusCode.OK, responseMessage.READ_GROUP_SUCCESS, {
+            dto,
+          }),
+        );
+    } catch (error) {
+      console.log(error);
+      return res
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(
+          util.fail(
+            statusCode.INTERNAL_SERVER_ERROR,
+            responseMessage.READ_GROUP_ALL_FAIL,
+          ),
+        );
+    }
+  },
   readGroupDetail: async (req, res) => {
     try {
       const { groupId } = req.params;

--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -170,9 +170,7 @@ module.exports = {
       return res
         .status(statusCode.OK)
         .send(
-          util.success(statusCode.OK, responseMessage.READ_GROUP_SUCCESS, {
-            dto,
-          }),
+          util.success(statusCode.OK, responseMessage.READ_GROUP_SUCCESS, dto),
         );
     } catch (error) {
       console.log(error);

--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -160,6 +160,7 @@ module.exports = {
         dto = {
           groupId,
           groupName: readGroup.groupName,
+          introduction: readGroup.introduction,
           countMember,
           maximumMemberNumber: readGroup.maximumMemberNumber,
         };

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -69,6 +69,8 @@ module.exports = {
   ALREADY_GROUP: '이미 그룹에 속해 있습니다.',
   JOIN_GROUP_SUCCESS: '그룹 참가 완료',
   JOIN_GROUP_FAIL: '그룹 참가 실패',
+  READ_GROUP_SUCCESS: '그룹 조회 성공',
+  READ_GROUP_FAIL: '그룹 조회 실패',
   READ_GROUP_ALL_SUCCESS: '그룹에 가입된 사용자의 전체 그룹 조회 성공',
   READ_GROUP_ALL_FAIL: '그룹에 가입된 사용자의 전체 그룹 조회 실패',
   MEMBER_NUMBER_LIMITATION: '그룹의 인원이 가득찼습니다.',

--- a/routes/group.js
+++ b/routes/group.js
@@ -6,6 +6,7 @@ const isLoggedIn = require('../middlewares/authUtil');
 const upload = require('../modules/multer');
 
 router.post('/', isLoggedIn.checkToken, groupController.createGroup);
+router.get('/my', isLoggedIn.checkToken, groupController.readMyGroup);
 router.get('/', isLoggedIn.checkToken, groupController.readGroupList);
 router.get('/:groupId', isLoggedIn.checkToken, groupController.readGroupDetail);
 router.post('/upload', upload.single('image'), groupController.createGroupImage);


### PR DESCRIPTION
## 작업사항

- 토큰을 받아 유저가 가입되어있는 그룹의 정보를 응답합니다.
- 가입된 그룹이 없는 경우 null을 리턴합니다.

related to #79

## 사용방법

[명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B0%80%EC%9E%85-%EA%B7%B8%EB%A3%B9-%EC%A1%B0%ED%9A%8C)

### 희망 리뷰 완료일

2021-01-13

### 관계된 이슈, PR 

#79 