### PR TITLE
[refactor]: 그룹리스트 조회 API가 더 이상 myGroup을 포함하지 않음

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -93,6 +93,13 @@ module.exports = {
         .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
     }
 
+    if (Number.isNaN(Number(offset))) {
+      console.log('파라미터 타입이 잘못되었습니다.');
+      return res
+        .status(statusCode.BAD_REQUEST)
+        .send(util.fail(statusCode.BAD_REQUEST, responseMessage.INVALID_PARAMETER_TYPE));
+    }
+
     try {
       const getGroupAll = await groupService.findAllGroupList(Number(offset));
 
@@ -117,30 +124,21 @@ module.exports = {
       const checkMemberId = await groupService.checkMemberId(id);
 
       if (!checkMemberId) {
-        console.log(responseMessage.NO_GROUP);
-        return res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.NO_GROUP, { myGroup: null, hasImageGroupList: getImageGroupList, noImageGroupList: getNoImageGroupList }));
+        console.log(responseMessage.READ_GROUP_SUCCESS);
+        return res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_GROUP_SUCCESS, { hasImageGroupList: getImageGroupList, noImageGroupList: getNoImageGroupList }));
       }
 
       const groupId = checkMemberId.GroupId;
-      const readGroup = await groupService.readGroup(groupId);
-      const countMember = await groupService.countMember(groupId);
-
-      const myGroup = {
-        groupId,
-        groupName: readGroup.groupName,
-        maximumMemberNumber: readGroup.maximumMemberNumber,
-        countMember,
-      };
 
       const hasImageGroupList = _.uniqBy(getImageGroupList, 'groupId')
         .filter((hasImageGroup) =>
-          hasImageGroup.groupId !== myGroup.groupId);
+          hasImageGroup.groupId !== groupId);
 
       const noImageGroupList = _.uniqBy(getNoImageGroupList, 'groupId')
         .filter((NoImageGroup) =>
-          NoImageGroup.groupId !== myGroup.groupId);
+          NoImageGroup.groupId !== groupId);
 
-      return res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_GROUP_ALL_SUCCESS, { myGroup, hasImageGroupList, noImageGroupList }));
+      return res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_GROUP_ALL_SUCCESS, { hasImageGroupList, noImageGroupList }));
     } catch (error) {
       console.log(error);
       return res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.READ_GROUP_ALL_FAIL));
@@ -192,10 +190,10 @@ module.exports = {
       const checkGroupId = await groupService.readGroup(groupId);
 
       if (!checkGroupId) {
-        console.log(responseMessage.NO_GROUP);
+        console.log(responseMessage.NO_SUCH_GROUP);
         return res
           .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_GROUP));
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_SUCH_GROUP));
       }
 
       const groupDetail = {
@@ -369,7 +367,7 @@ module.exports = {
       if (!groupName || !introduction || !maximumMemberNumber) {
         return res
           .status(statusCode.BAD_REQUEST)
-          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_GROUP));
+          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_SUCH_GROUP));
       }
 
       const group = {

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -2,6 +2,7 @@
 module.exports = {
   NULL_VALUE: '필요한 값이 없습니다.',
   OUT_OF_VALUE: '파라미터 값이 잘못 되었습니다.',
+  INVALID_PARAMETER_TYPE: '파라미터 타입이 잘못되었습니다.',
 
   /* 회원가입 */
   SIGN_UP_SUCCESS: '회원 가입 성공.',
@@ -67,9 +68,10 @@ module.exports = {
   CREATE_POST_SUCCESS: '그룹에 타임스탬프가 포스팅되었습니다.',
 
   /* 그룹 */
-  NO_GROUP: '존재하지 않는 그룹의 ID입니다.',
+  NO_SUCH_GROUP: '존재하지 않는 그룹의 ID입니다.',
   CREATE_GROUP_SUCCESS: '그룹 생성 완료',
   CREATE_GROUP_FAIL: '그룹 생성 실패',
+  NO_GROUP: '가입된 그룹이 없습니다.',
   ALREADY_GROUP: '이미 그룹에 속해 있습니다.',
   JOIN_GROUP_SUCCESS: '그룹 참가 완료',
   JOIN_GROUP_FAIL: '그룹 참가 실패',


### PR DESCRIPTION
## 작업사항

- [이용자가 속한 그룹을 조회하는 API](https://github.com/nneaning/meaning_Server/wiki/%EA%B0%80%EC%9E%85-%EA%B7%B8%EB%A3%B9-%EC%A1%B0%ED%9A%8C)가 만들어짐에 따라, 대체 될 수 있는 만큼을 삭제했습니다.

## 변경로직

더 이상 요청 이용자가 가입된 그룹의 정보를 그룹 리스트 조회 API에서 응답하지 않습니다.

## 사용방법

[명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EB%A6%AC%EC%8A%A4%ED%8A%B8)

### 희망 리뷰 완료일

2021-01-14

### 관계된 이슈, PR 

related to #23