### PR TITLE
[fix]: 그룹 설정 정보 응답에 그룹 생성일 포함하여 응답

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -362,9 +362,10 @@ module.exports = {
         groupName,
         introduction,
         maximumMemberNumber,
+        createdAt,
       } = await groupService.readGroup(groupId);
 
-      if (!groupName || !introduction || !maximumMemberNumber) {
+      if (!groupName || !introduction || !maximumMemberNumber || !createdAt) {
         return res
           .status(statusCode.BAD_REQUEST)
           .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_SUCH_GROUP));
@@ -375,15 +376,16 @@ module.exports = {
         groupName,
         introduction,
         maximumMemberNumber,
+        createdAt,
       };
 
       const users = await groupService.readAllUsers(groupId);
       for (const { dataValues } of users) {
-        const { createdAt } = await groupService.checkMemberId(dataValues.id);
+        const { createdAt: memberCreatedAt } = await groupService.checkMemberId(dataValues.id);
         dataValues.dayPassed = Math.floor(
           dateTimeModule.getDateDifference(
             dayjs().format(dateTimeModule.FORMAT_DATETIME),
-            createdAt,
+            memberCreatedAt,
           ) + 1,
         );
       }


### PR DESCRIPTION


## 작업사항

- 해당 뷰에서 필요한 데이터(그룹 생성일)이 누락되어 수정합니다.

### 변경전

```
const {
        groupName,
        introduction,
        maximumMemberNumber,
      } = await groupService.readGroup(groupId);

      if (!groupName || !introduction || !maximumMemberNumber) {
        return res
          .status(statusCode.BAD_REQUEST)
          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_SUCH_GROUP));
      }

      const group = {
        groupId,
        groupName,
        introduction,
        maximumMemberNumber,
      };
```

### 변경후

```
const {
        groupName,
        introduction,
        maximumMemberNumber,
        createdAt,
      } = await groupService.readGroup(groupId);

      if (!groupName || !introduction || !maximumMemberNumber || !createdAt) {
        return res
          .status(statusCode.BAD_REQUEST)
          .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_SUCH_GROUP));
      }

      const group = {
        groupId,
        groupName,
        introduction,
        maximumMemberNumber,
        createdAt,
      };
```

## 사용방법

[명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EC%84%A4%EC%A0%95)

### 희망 리뷰 완료일

2021-01-14

### 관계된 이슈, PR 

related to #51