### PR TITLE
[fix]: 잘못된 비밀번호로 로그인을 시도했을 때 응답 메세지가 제대로 송신되지 않는 문제 해결

### DIFF
--- a/controller/userController.js
+++ b/controller/userController.js
@@ -82,9 +82,9 @@ module.exports = {
       if (await userService.encryptPassword(password, salt) !== realPassword) {
         console.log('비밀번호가 일치하지 않습니다.');
         return res
-          .status(statusCode.BAD_REQUEST)
+          .status(statusCode.UNAUTHORIZED)
           .send(
-            util.fail(statusCode.BAD_REQUEST, responseMessage.MISS_MATCH_PW),
+            util.fail(statusCode.UNAUTHORIZED, responseMessage.MISS_MATCH_PW),
           );
       }
 

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -7,7 +7,7 @@ const jwt = require('../modules/jwt');
 const util = require('../modules/util');
 const responseMessage = require('../modules/responseMessage');
 const statusCode = require('../modules/statusCode');
-
+const encryptModule = require('../modules/encryptModule');
 const dateTimeModule = require('../modules/dateTimeModule');
 
 const { dayjs } = dateTimeModule;
@@ -79,7 +79,7 @@ module.exports = {
 
       const { salt, password: realPassword } = checkEmail;
 
-      if (await userService.encryptPassword(password, salt) !== realPassword) {
+      if (encryptModule.encryptPassword(password, salt) !== realPassword) {
         console.log('비밀번호가 일치하지 않습니다.');
         return res
           .status(statusCode.UNAUTHORIZED)

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -77,10 +77,9 @@ module.exports = {
           .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_USER));
       }
 
-      const { salt, password: hashedPassword } = checkEmail;
-      const user = await userService.signin(email, password, salt);
+      const { salt, password: realPassword } = checkEmail;
 
-      if (user.password !== hashedPassword) {
+      if (await userService.encryptPassword(password, salt) !== realPassword) {
         console.log('비밀번호가 일치하지 않습니다.');
         return res
           .status(statusCode.BAD_REQUEST)
@@ -88,6 +87,8 @@ module.exports = {
             util.fail(statusCode.BAD_REQUEST, responseMessage.MISS_MATCH_PW),
           );
       }
+
+      const user = await userService.signin(email, password, salt);
 
       const { accessToken, refreshToken } = await jwt.sign(user);
       return res.status(statusCode.OK).send(
@@ -102,7 +103,7 @@ module.exports = {
       console.log(error);
       return res
         .status(statusCode.INTERNAL_SERVER_ERROR)
-        .send(util.fail(statusCode.BAD_REQUEST, responseMessage.SIGN_IN_FAIL));
+        .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.SIGN_IN_FAIL));
     }
   },
   getMyPage: async (req, res) => {

--- a/modules/encryptModule.js
+++ b/modules/encryptModule.js
@@ -1,0 +1,16 @@
+const crypto = require('crypto');
+
+function encryptPassword(password, salt) {
+  return crypto
+    .pbkdf2Sync(password, salt, 10000, 64, 'sha512')
+    .toString('base64');
+}
+
+function generateSalt() {
+  return crypto.randomBytes(64).toString('base64');
+}
+
+module.exports = {
+  encryptPassword,
+  generateSalt,
+};

--- a/service/userService.js
+++ b/service/userService.js
@@ -8,6 +8,16 @@ const {
 
 const GETMYPAGE_QUERY_UNIT = 18;
 
+async function encryptPassword(password, salt) {
+  try {
+    return crypto
+      .pbkdf2Sync(password, salt, 10000, 64, 'sha512')
+      .toString('base64');
+  } catch (error) {
+    throw error;
+  }
+}
+
 module.exports = {
   checkEmail: async (email) => {
     try {
@@ -66,6 +76,7 @@ module.exports = {
       throw err;
     }
   },
+  encryptPassword,
   updateRefreshToken: async (id, refreshToken) => {
     try {
       const user = await User.update(

--- a/service/userService.js
+++ b/service/userService.js
@@ -1,22 +1,13 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-useless-catch */
 
-const crypto = require('crypto');
 const {
   User, TimeStamp, TodaysPromise, BookComment, Diary,
 } = require('../models');
 
-const GETMYPAGE_QUERY_UNIT = 18;
+const encryptModule = require('../modules/encryptModule');
 
-async function encryptPassword(password, salt) {
-  try {
-    return crypto
-      .pbkdf2Sync(password, salt, 10000, 64, 'sha512')
-      .toString('base64');
-  } catch (error) {
-    throw error;
-  }
-}
+const GETMYPAGE_QUERY_UNIT = 18;
 
 module.exports = {
   checkEmail: async (email) => {
@@ -45,8 +36,8 @@ module.exports = {
   },
   signup: async (email, userName, password) => {
     try {
-      const salt = crypto.randomBytes(64).toString('base64');
-      const hashedPassword = await encryptPassword(password, salt);
+      const salt = encryptModule.generateSalt();
+      const hashedPassword = encryptModule.encryptPassword(password, salt);
       const user = await User.create({
         email,
         userName,
@@ -60,7 +51,7 @@ module.exports = {
   },
   signin: async (email, password, salt) => {
     try {
-      const inputPassword = await encryptPassword(password, salt);
+      const inputPassword = encryptModule.encryptPassword(password, salt);
       const user = await User.findOne({
         where: {
           email,
@@ -72,7 +63,6 @@ module.exports = {
       throw err;
     }
   },
-  encryptPassword,
   updateRefreshToken: async (id, refreshToken) => {
     try {
       const user = await User.update(

--- a/service/userService.js
+++ b/service/userService.js
@@ -46,9 +46,7 @@ module.exports = {
   signup: async (email, userName, password) => {
     try {
       const salt = crypto.randomBytes(64).toString('base64');
-      const hashedPassword = crypto
-        .pbkdf2Sync(password, salt, 10000, 64, 'sha512')
-        .toString('base64');
+      const hashedPassword = await encryptPassword(password, salt);
       const user = await User.create({
         email,
         userName,
@@ -62,9 +60,7 @@ module.exports = {
   },
   signin: async (email, password, salt) => {
     try {
-      const inputPassword = crypto
-        .pbkdf2Sync(password, salt, 10000, 64, 'sha512')
-        .toString('base64');
+      const inputPassword = await encryptPassword(password, salt);
       const user = await User.findOne({
         where: {
           email,


### PR DESCRIPTION
## 작업사항

다음과 같은 문제가 발생하였습니다.
1. 잘못된 비밀번호로 로그인 하였을 때 클라이언트 측에서는 응답코드 400과 함께 '로그인 실패'라는 메세지를 받았습니다. 잘못된 비밀번호를 입력한 경우, '비밀번호가 일치하지 않습니다.'라는 메세지가 수신되기를 예상하며 그러한 코드도 작성되어 있으나, 작동하지 않았습니다.
2. 서버측의 로그에는 HTTP Status Code 500으로 기록됩니다. 이러한 현상이 발생한 이유는,
- 잘못된 비밀번호를 암호화하여 DB를 탐색하기 때문에 리턴되는 계정 정보가 없음
- 따라서 null이 반환되는데, null에서 password 필드를 읽어오려 함
- 내부적으로 예외가 발생하고, 이는 예외 처리문에 의해 처리됨
- 그러나 예외처리문에서는 상태코드 500이 아닌 400으로 응답

따라서, 이와 같은 문제를 해결하고, 예상치 못한 예외가 발생한 경우 500으로 응답하도록 수정하였습니다.

## 사용방법

[명세서](https://github.com/nneaning/meaning_Server/wiki/%EB%A1%9C%EA%B7%B8%EC%9D%B8)

### 희망 리뷰 완료일

2021-01-14