### PR TITLE
[fix]: 그룹 생성 시 그룹명 중복 검사 및 응답 코드 구분화

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -29,13 +29,22 @@ module.exports = {
     }
     try {
       const checkMemberId = await groupService.checkMemberId(id);
-
       if (checkMemberId) {
         console.log(responseMessage.ALREADY_GROUP);
         return res
-          .status(statusCode.BAD_REQUEST)
+          .status(statusCode.FORBIDDEN)
           .send(
-            util.fail(statusCode.BAD_REQUEST, responseMessage.ALREADY_GROUP),
+            util.fail(statusCode.FORBIDDEN, responseMessage.ALREADY_GROUP),
+          );
+      }
+
+      const checkGroupName = await groupService.readGroupByName(groupName);
+      if (checkGroupName) {
+        console.log(responseMessage.ALREADY_GROUP_NAME);
+        return res
+          .status(statusCode.NOT_ACCEPTABLE)
+          .send(
+            util.fail(statusCode.NOT_ACCEPTABLE, responseMessage.ALREADY_GROUP_NAME),
           );
       }
 

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -73,6 +73,7 @@ module.exports = {
   CREATE_GROUP_FAIL: '그룹 생성 실패',
   NO_GROUP: '가입된 그룹이 없습니다.',
   ALREADY_GROUP: '이미 그룹에 속해 있습니다.',
+  ALREADY_GROUP_NAME: '이미 있는 그룹명입니다.',
   JOIN_GROUP_SUCCESS: '그룹 참가 완료',
   JOIN_GROUP_FAIL: '그룹 참가 실패',
   READ_GROUP_SUCCESS: '그룹 조회 성공',

--- a/service/groupService.js
+++ b/service/groupService.js
@@ -33,6 +33,18 @@ module.exports = {
       throw err;
     }
   },
+  readGroupByName: async (groupName) => {
+    try {
+      const group = await Group.findOne({
+        where: {
+          groupName,
+        },
+      });
+      return group;
+    } catch (err) {
+      throw err;
+    }
+  },
   checkMemberId: async (id) => {
     try {
       const findMemberId = await Member.findOne({


### PR DESCRIPTION
## 작업사항

- 그룹 생성 시 DB에서 이미 해당 그룹명을 가지고 있는지 검사하는 로직을 추가했습니다.
- 또한 요청 거부시 서버 내부 오류를 제외하고 모두 Status Code 400으로 응답하는 것을 수정했습니다.

## 사용방법

[명세서](https://github.com/nneaning/meaning_Server/wiki/%EA%B7%B8%EB%A3%B9-%EC%83%9D%EC%84%B1)

### 희망 리뷰 완료일

2021-01-14

### 관계된 이슈, PR 
#31 