### PR TITLE
[fix]: 그룹생성 API에서 groupImage를 제공받지 못한 에러 해결

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -53,7 +53,7 @@ module.exports = {
       );
       const countGroupImageId = await groupService.countGroupImageId();
 
-      const groupImageId = Number(groupId % countGroupImageId.length);
+      const groupImageId = Number(groupId % countGroupImageId.length + 1);
 
       const createGroupProfile = await groupService.createGroupProfile(
         groupId,


### PR DESCRIPTION
## 작업사항

- 그룹의 id값에서 미리 저장해둔 그룹이미지의 갯수를 나누고, 나눈 값을 그룹이미지의 id로 받는 과정에서,
- id가 0으로 받아져서 이미지가 모두 저장되지 않은 버그 수정

### 희망 리뷰 완료일

- 2021-01-14

### 관계된 이슈, PR 

- #31
