### PR TITLE
[fix]: 타임스탬프 작성 API 사진 미첨부에 대한 예외처리

### DIFF
--- a/controller/timeStampController.js
+++ b/controller/timeStampController.js
@@ -26,7 +26,19 @@ module.exports = {
     try {
       const userId = req.decoded.id;
       const wakeUpTime = await userService.getWakeUpTime(userId);
+
+      if (!req.file) {
+        return res
+          .status(statusCode.BAD_REQUEST)
+          .send(
+            util.fail(
+              statusCode.BAD_REQUEST,
+              responseMessage.NO_IMAGE,
+            ),
+          );
+      }
       const timeStampImageUrl = req.file.location;
+
       const { dateTime, timeStampContents } = req.body;
 
       if (!dateTime || !timeStampContents || !timeStampImageUrl) {

--- a/modules/responseMessage.js
+++ b/modules/responseMessage.js
@@ -32,6 +32,7 @@ module.exports = {
   READ_TIMESTAMP_ALL_FAIL: '전체 타임스탬프 조회 실패',
   READ_TIMESTAMP_SUCCESS: '타임스탬프 조회 성공',
   READ_TIMESTAMP_FAIL: '타임스탬프 조회 실패',
+  NO_IMAGE: '이미지 파일을 읽어올 수 없습니다.',
   INVALID_TIMESTAMP_ID: '유효하지 않은 타임스탬프의 id값입니다.',
 
   /* 캘린더 */


### PR DESCRIPTION
## 작업사항

- 타임스탬프 작성 API 요청 시, 사진을 첨부하지 않았을 때 발생하는 예외를 try ~ catch 문에 의해 처리하게 두었습니다. 따라서 클라이언트는 어떤 이유 때문에 응답이 거절됐는지 알 수 없었습니다. 이에 if문에 의한 예외처리문을 작성합니다.

## 변경로직
- 하단의 예외 처리를 위한 조건문 추가
```
if (!req.file) {
        return res
          .status(statusCode.BAD_REQUEST)
          .send(
            util.fail(
              statusCode.BAD_REQUEST,
              responseMessage.NO_IMAGE,
            ),
          );
      }
```

### 변경전

- 사진 미첨부시 500 코드로 응답합니다.

### 변경후

- 사진 미첨부시 if 문에 의해 400 코드로 응답합니다.

### 희망 리뷰 완료일

2021-01-14

### 관계된 이슈, PR 

related to #9 #41