### PR TITLE
[feat]: 마이페이지 정보 요청시 리사이징된 이미지 URL을 전송

### DIFF
--- a/controller/userController.js
+++ b/controller/userController.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 /* eslint-disable arrow-parens */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-return-assign */
@@ -125,6 +126,10 @@ module.exports = {
 
       getMySuccessDay.forEach(day =>
         (successDays += day.status));
+
+      for (const { dataValues } of getMyPage) { // send resized image URL
+        dataValues.timeStampImageUrl = dataValues.timeStampImageUrl.replace('/images/origin', '/images/w_200');
+      }
 
       return res
         .status(statusCode.OK)


### PR DESCRIPTION
## 작업사항 및 변경로직

- AWS Lambda Serverless 서비스를 이용하여, 이미지를 리사이징하여 저장하게 되었습니다.
- 그리고 필요에 따라 원본을 보낼지 리사이징한 것을 보낼지 결정합니다.
- 마이페이지 뷰는 작은 이미지로 충분하여, 가장 작게 리사이징된 이미지를 보냅니다.
- 다음의 코드를 통해 url의 일부를 수정하여 보냅니다.

```
for (const { dataValues } of getMyPage) { // send resized image URL
        dataValues.timeStampImageUrl = dataValues.timeStampImageUrl.replace('/images/origin', '/images/w_200');
      }
```

## 사용방법

- [API명세서](https://github.com/nneaning/meaning_Server/wiki/%EB%A7%88%EC%9D%B4%ED%8E%98%EC%9D%B4%EC%A7%80)

### 희망 리뷰 완료일

2021-01-14

### 관계된 이슈, PR 

#20