### PR TITLE
[fix]: 그룹생성 API에서 그룹 생성 시, 그룹 이미지가 생성되지 않은 에러 해결

### DIFF
--- a/controller/groupController.js
+++ b/controller/groupController.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-mixed-operators */
 /* eslint-disable dot-notation */
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-restricted-syntax */
@@ -53,8 +54,8 @@ module.exports = {
       );
       const countGroupImageId = await groupService.countGroupImageId();
 
-      const groupImageId = Number(groupId % countGroupImageId.length);
-
+      const groupImageId = Number(groupId % countGroupImageId.length + 1);
+      console.log(groupImageId);
       const createGroupProfile = await groupService.createGroupProfile(
         groupId,
         groupImageId,

--- a/service/groupService.js
+++ b/service/groupService.js
@@ -85,11 +85,11 @@ module.exports = {
       throw err;
     }
   },
-  createGroupProfile: async (groupId, countGroupImageId) => {
+  createGroupProfile: async (groupId, groupImageId) => {
     try {
       const makeGroupProfile = await GroupProfile.create({
         GroupId: groupId,
-        GroupImageId: countGroupImageId,
+        GroupImageId: groupImageId,
       });
       return makeGroupProfile;
     } catch (err) {


### PR DESCRIPTION
## 작업사항

- 그룹의 id값에서 미리 저장해둔 그룹이미지의 갯수를 나누고, 나눈 값을 그룹이미지의 id로 받는 과정에서,
- id가 0으로 받아져서 이미지가 모두 저장되지 않은 버그 수정
- 변수명의 중복으로 인해 생긴 문제라고 판단.

### 희망 리뷰 완료일

- 2021-01-15

### 관계된 이슈, PR 

- #31
